### PR TITLE
Fix: Update Drizzle config and resolve build error

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,15 +1,15 @@
-import type { Config } from 'drizzle-kit'
+import { defineConfig } from 'drizzle-kit'
 import * as dotenv from 'dotenv'
 
 // Load environment variables from .env.local
 dotenv.config({ path: '.env.local' })
 
-export default {
+export default defineConfig({
   schema: './lib/db.ts',
   out: './drizzle',
-  driver: 'turso',
+  dialect: 'turso',
   dbCredentials: {
     url: process.env.TURSO_DATABASE_URL!,
     authToken: process.env.TURSO_AUTH_TOKEN!,
   },
-} satisfies Config 
+})


### PR DESCRIPTION
Updated `drizzle.config.ts` to use the `dialect` property instead of `driver`, following the latest `drizzle-kit` version. This resolves the initial TypeScript error.