### PR TITLE
build: Disable @next/next/no-img-element ESLint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
 }


### PR DESCRIPTION
This commit disables the `@next/next/no-img-element` ESLint rule by adding a rule configuration to `.eslintrc.json`. This is done to allow the use of the standard `<img>` element in the project.