### PR TITLE
Feat: Add Blueprints category to resources

### DIFF
--- a/app/components/EditResourceModal.tsx
+++ b/app/components/EditResourceModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 
-const CATEGORY_OPTIONS = ['Raw', 'Refined', 'Components', 'Other']
+const CATEGORY_OPTIONS = ['Raw', 'Refined', 'Components', 'Blueprints', 'Other']
 
 interface Resource {
   id: string

--- a/app/components/ResourceTable.tsx
+++ b/app/components/ResourceTable.tsx
@@ -180,7 +180,7 @@ interface CongratulationsState {
 // Note: Role checking now done server-side in auth.ts and passed via session.user.permissions
 
 // Category options for dropdown
-const CATEGORY_OPTIONS = ['Raw', 'Refined', 'Components', 'Other']
+const CATEGORY_OPTIONS = ['Raw', 'Refined', 'Components', 'Blueprints', 'Other']
 
 export function ResourceTable({ userId }: ResourceTableProps) {
   const { data: session } = useSession()


### PR DESCRIPTION
This commit adds a new "Blueprints" category to the list of available resource categories.

The changes were made in the following files:
- app/components/EditResourceModal.tsx
- app/components/ResourceTable.tsx

The category list is hardcoded in these two components, so the new category was added to both arrays.