### PR TITLE
feat: Add User Management page

### DIFF
--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { db, users } from '@/lib/db'
+import { hasUserManagementAccess } from '@/lib/discord-roles'
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+
+  if (!session || !session.user.permissions?.hasUserManagementAccess) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  try {
+    const allUsers = await db.select({
+      username: users.username,
+      customNickname: users.customNickname,
+      createdAt: users.createdAt,
+      lastLogin: users.lastLogin,
+    }).from(users);
+
+    return NextResponse.json(allUsers, {
+      headers: {
+        'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate',
+        'Pragma': 'no-cache',
+        'Expires': '0'
+      }
+    })
+  } catch (error) {
+    console.error('Error fetching users:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch users' },
+      { status: 500 })
+  }
+}

--- a/app/components/UserTable.tsx
+++ b/app/components/UserTable.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+interface User {
+  username: string
+  customNickname: string
+  createdAt: string
+  lastLogin: string
+}
+
+export function UserTable() {
+  const [users, setUsers] = useState<User[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      try {
+        setLoading(true)
+        const response = await fetch('/api/users')
+        if (response.ok) {
+          const data = await response.json()
+          setUsers(data)
+        }
+      } catch (error) {
+        console.error('Error fetching users:', error)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchUsers()
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="p-8 text-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
+        <p className="mt-2 text-gray-600 dark:text-gray-400">
+          Loading users...
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow-xs rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-900">
+            <tr>
+              <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                Username
+              </th>
+              <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                Custom Nickname
+              </th>
+              <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                Created At
+              </th>
+              <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                Last Login
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            {users.map((user) => (
+              <tr key={user.username}>
+                <td className="px-3 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                  {user.username}
+                </td>
+                <td className="px-3 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                  {user.customNickname}
+                </td>
+                <td className="px-3 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                  {new Date(user.createdAt).toLocaleString()}
+                </td>
+                <td className="px-3 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                  {new Date(user.lastLogin).toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -63,6 +63,36 @@ export default async function Dashboard() {
             </div>
           )}
 
+          {/* User Management - Prominent Section */}
+          {session.user.permissions?.hasUserManagementAccess && (
+            <div className="mb-8">
+              <div className="bg-linear-to-r from-red-600 to-red-700 rounded-lg shadow-lg p-6 text-white">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h2 className="text-2xl font-bold mb-2">User Management</h2>
+                    <p className="text-red-100 mb-4">
+                      View and manage user data
+                    </p>
+                    <Link
+                      href="/users"
+                      className="bg-white text-red-700 hover:bg-red-50 px-6 py-3 rounded-lg font-semibold transition-colors flex items-center gap-2 inline-flex"
+                    >
+                      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M15 21v-1a6 6 0 00-5.197-5.197" />
+                      </svg>
+                      Manage Users
+                    </Link>
+                  </div>
+                  <div className="hidden md:block">
+                    <svg className="w-20 h-20 text-red-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M15 21v-1a6 6 0 00-5.197-5.197" />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {/* User Info Card */}
             <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 border border-gray-200 dark:border-gray-700">

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,0 +1,34 @@
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { ClientNavigation } from '../components/ClientNavigation'
+import { UserTable } from '../components/UserTable'
+
+export default async function UsersPage() {
+  const session = await getServerSession(authOptions)
+
+  if (!session) {
+    redirect('/')
+  }
+
+  if (!session.user.permissions?.hasUserManagementAccess) {
+    redirect('/dashboard')
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-300">
+      <ClientNavigation title="User Management" showDashboardLink={true} />
+
+      <main className="container mx-auto px-4 py-8">
+        <div className="max-w-7xl mx-auto">
+          <header className="mb-8">
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200 mb-2">User Management</h1>
+            <p className="text-gray-600 dark:text-gray-400">View and manage user data</p>
+          </header>
+
+          <UserTable />
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,6 +7,7 @@ const protectedRoutes = [
   '/resources',
   '/api/resources',
   '/api/user',
+  '/api/users',
 ]
 
 export default withAuth(
@@ -37,5 +38,5 @@ export default withAuth(
 )
 
 export const config = {
-  matcher: ['/dashboard/:path*', '/resources/:path*']
+  matcher: ['/dashboard/:path*', '/resources/:path*', '/users/:path*']
 } 


### PR DESCRIPTION
This commit introduces a new User Management page accessible to users with the 'isAdmin' permission.

The new page is available at `/users` and displays a table of users with their username, custom nickname, creation date, and last login time.

The key changes include:
- A new API endpoint at `/api/users` to fetch user data, protected by the `hasUserManagementAccess` permission.
- A new `UserTable` component to display the user data.
- A new `users` page that renders the `UserTable`.
- A new "User Management" section on the dashboard, styled in red, which is only visible to admins and links to the new page.
- Updated middleware to protect the new routes.