### PR TITLE
Feat: Add Transfer button to ResourceTable in Table mode

### DIFF
--- a/app/components/ResourceTable.tsx
+++ b/app/components/ResourceTable.tsx
@@ -2060,6 +2060,19 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                 Set
                               </button>
                             </div>
+                            <div className="flex gap-1">
+                              <button
+                                onClick={() =>
+                                  setTransferModalState({
+                                    isOpen: true,
+                                    resource: resource,
+                                  })
+                                }
+                                className="flex-1 bg-green-100 dark:bg-green-900/50 hover:bg-green-200 dark:hover:bg-green-900/70 text-green-700 dark:text-green-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                              >
+                                Transfer
+                              </button>
+                            </div>
 
                             {/* Admin buttons */}
                             {isResourceAdmin && (


### PR DESCRIPTION
This commit adds the 'Transfer' button to the `ResourceTable.tsx` component when it is in 'Table' mode. This button was previously only available in 'Grid' mode.

The new button has the same functionality as the one in the grid view, opening a modal to transfer resources between Hagga and Deep Desert. The styling is consistent with the other action buttons in the table view.