### PR TITLE
Feature/change target modal

### DIFF
--- a/app/components/ChangeTargetModal.tsx
+++ b/app/components/ChangeTargetModal.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+interface ChangeTargetModalProps {
+  resource: {
+    id: string
+    name: string
+    targetQuantity?: number
+  }
+  isOpen: boolean
+  onClose: () => void
+  onSave: (resourceId: string, newTarget: number) => Promise<void>
+}
+
+export function ChangeTargetModal({
+  resource,
+  isOpen,
+  onClose,
+  onSave,
+}: ChangeTargetModalProps) {
+  const [target, setTarget] = useState(resource.targetQuantity || 0)
+  const [error, setError] = useState<string | null>(null)
+  const [showModal, setShowModal] = useState(false)
+  const [isAnimating, setIsAnimating] = useState(false)
+
+  useEffect(() => {
+    if (isOpen) {
+      setShowModal(true)
+      const timer = setTimeout(() => setIsAnimating(true), 10)
+      return () => clearTimeout(timer)
+    } else {
+      setIsAnimating(false)
+      const timer = setTimeout(() => setShowModal(false), 300) // Animation duration
+      return () => clearTimeout(timer)
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (resource) {
+      setTarget(resource.targetQuantity || 0);
+    }
+  }, [resource]);
+
+
+  const handleSave = async () => {
+    setError(null)
+    if (target < 0) {
+      setError('Target cannot be negative.')
+      return
+    }
+
+    try {
+      await onSave(resource.id, target)
+      onClose()
+    } catch (err: any) {
+      setError(err.message || 'An error occurred.')
+    }
+  }
+
+  if (!showModal) return null
+
+  return (
+    <div
+      className={`fixed inset-0 flex items-center justify-center z-50 transition-colors duration-300 ease-in-out ${
+        isAnimating ? 'bg-black/50' : 'bg-black/0'
+      }`}
+    >
+      <div
+        className={`bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md mx-4 border border-gray-200 dark:border-gray-700 transition-all duration-300 ease-in-out transform ${
+          isAnimating ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
+        }`}
+      >
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+          Change Target for {resource.name}
+        </h3>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              New Target Quantity
+            </label>
+            <input
+              type="number"
+              min="0"
+              value={target}
+              onChange={(e) => setTarget(parseInt(e.target.value) || 0)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+            />
+          </div>
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+        </div>
+        <div className="flex gap-3 justify-end mt-6">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-600 hover:bg-gray-200 dark:hover:bg-gray-500 rounded-lg transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 rounded-lg transition-colors"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/ResourceTable.tsx
+++ b/app/components/ResourceTable.tsx
@@ -1761,7 +1761,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                   }}
                                   className="flex-1 bg-purple-100 dark:bg-purple-900/50 hover:bg-purple-200 dark:hover:bg-purple-900/70 text-purple-700 dark:text-purple-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                                 >
-                                  Set
+                                  Set Qty
                                 </button>
                               </div>
                               <div className="flex gap-1">
@@ -1786,7 +1786,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                         resource: resource,
                                       })
                                     }}
-                                    className="flex-1 bg-gray-100 dark:bg-gray-900/50 hover:bg-gray-200 dark:hover:bg-gray-900/70 text-gray-700 dark:text-gray-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                                    className="flex-1 bg-orange-100 dark:bg-orange-900/50 hover:bg-orange-200 dark:hover:bg-orange-900/70 text-orange-700 dark:text-orange-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                                   >
                                     Set Target
                                   </button>
@@ -1839,7 +1839,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
             <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
               <thead className="bg-gray-50 dark:bg-gray-900">
                 <tr>
-                  <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-1/4">
                     Resource
                   </th>
                   <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
@@ -1859,7 +1859,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                       Target
                     </th>
                   )}
-                  <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-48">
                     Actions
                   </th>
                 </tr>
@@ -1894,7 +1894,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                           : 'Click to view detailed resource information'
                       }
                     >
-                      <td className="px-3 py-3 whitespace-nowrap">
+                      <td className="px-3 py-3">
                         <div className="flex items-center">
                           <div className="shrink-0 h-12 w-12">
                             {resource.imageUrl ? (
@@ -1922,7 +1922,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                             </div>
                           </div>
                           <div className="ml-4">
-                            <div className="text-sm font-medium text-gray-900 dark:text-gray-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+                            <div className="text-sm font-medium text-gray-900 dark:text-gray-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors break-words">
                               {resource.name}
                               <svg
                                 className="w-3 h-3 inline ml-1 opacity-0 group-hover:opacity-100 transition-opacity"
@@ -1989,7 +1989,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                       )}
 
                       <td
-                        className="px-3 py-3 whitespace-nowrap text-sm"
+                        className="px-3 py-3 text-sm"
                         onClick={(e) => e.stopPropagation()}
                       >
                         <div className="space-y-2">
@@ -2018,7 +2018,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                 }
                                 className="flex-1 bg-purple-100 dark:bg-purple-900/50 hover:bg-purple-200 dark:hover:bg-purple-900/70 text-purple-700 dark:text-purple-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                               >
-                                Set
+                                  Set Qty
                               </button>
                             </div>
                             <div className="flex gap-1">
@@ -2041,7 +2041,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                       resource: resource,
                                     })
                                   }
-                                  className="flex-1 bg-gray-100 dark:bg-gray-900/50 hover:bg-gray-200 dark:hover:bg-gray-900/70 text-gray-700 dark:text-gray-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                                  className="flex-1 bg-orange-100 dark:bg-orange-900/50 hover:bg-orange-200 dark:hover:bg-orange-900/70 text-orange-700 dark:text-orange-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                                 >
                                   Set Target
                                 </button>

--- a/app/components/ResourceTable.tsx
+++ b/app/components/ResourceTable.tsx
@@ -2004,7 +2004,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                     updateType: UPDATE_TYPE.RELATIVE,
                                   })
                                 }
-                                className="flex-1 bg-blue-100 dark:bg-blue-900/50 hover:bg-blue-200 dark:hover:bg-blue-900/70 text-blue-700 dark:text-blue-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                                className="flex-1 min-w-fit bg-blue-100 dark:bg-blue-900/50 hover:bg-blue-200 dark:hover:bg-blue-900/70 text-blue-700 dark:text-blue-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                               >
                                 Add/Remove
                               </button>
@@ -2016,7 +2016,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                     updateType: UPDATE_TYPE.ABSOLUTE,
                                   })
                                 }
-                                className="flex-1 bg-purple-100 dark:bg-purple-900/50 hover:bg-purple-200 dark:hover:bg-purple-900/70 text-purple-700 dark:text-purple-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                                className="flex-1 min-w-fit bg-purple-100 dark:bg-purple-900/50 hover:bg-purple-200 dark:hover:bg-purple-900/70 text-purple-700 dark:text-purple-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                               >
                                   Set Qty
                               </button>
@@ -2029,7 +2029,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                     resource: resource,
                                   })
                                 }
-                                className="flex-1 bg-green-100 dark:bg-green-900/50 hover:bg-green-200 dark:hover:bg-green-900/70 text-green-700 dark:text-green-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                                className="flex-1 min-w-fit bg-green-100 dark:bg-green-900/50 hover:bg-green-200 dark:hover:bg-green-900/70 text-green-700 dark:text-green-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                               >
                                 Transfer
                               </button>
@@ -2041,7 +2041,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                       resource: resource,
                                     })
                                   }
-                                  className="flex-1 bg-orange-100 dark:bg-orange-900/50 hover:bg-orange-200 dark:hover:bg-orange-900/70 text-orange-700 dark:text-orange-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                                  className="flex-1 min-w-fit bg-orange-100 dark:bg-orange-900/50 hover:bg-orange-200 dark:hover:bg-orange-900/70 text-orange-700 dark:text-orange-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                                 >
                                   Set Target
                                 </button>
@@ -2053,7 +2053,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                               <div className="flex gap-1">
                                 <button
                                   onClick={() => startEditResource(resource)}
-                                  className="flex-1 bg-yellow-100 dark:bg-yellow-900/50 hover:bg-yellow-200 dark:hover:bg-yellow-900/70 text-yellow-700 dark:text-yellow-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                                  className="flex-1 min-w-fit bg-yellow-100 dark:bg-yellow-900/50 hover:bg-yellow-200 dark:hover:bg-yellow-900/70 text-yellow-700 dark:text-yellow-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                                 >
                                   Edit
                                 </button>
@@ -2065,7 +2065,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                       showDialog: true,
                                     })
                                   }
-                                  className="flex-1 bg-red-100 dark:bg-red-900/50 hover:bg-red-200 dark:hover:bg-red-900/70 text-red-700 dark:text-red-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                                  className="flex-1 min-w-fit bg-red-100 dark:bg-red-900/50 hover:bg-red-200 dark:hover:bg-red-900/70 text-red-700 dark:text-red-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                                 >
                                   Delete
                                 </button>

--- a/app/components/ResourceTable.tsx
+++ b/app/components/ResourceTable.tsx
@@ -2004,7 +2004,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                     updateType: UPDATE_TYPE.RELATIVE,
                                   })
                                 }
-                                className="flex-1 min-w-fit bg-blue-100 dark:bg-blue-900/50 hover:bg-blue-200 dark:hover:bg-blue-900/70 text-blue-700 dark:text-blue-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                                className="flex-1 min-w-20 bg-blue-100 dark:bg-blue-900/50 hover:bg-blue-200 dark:hover:bg-blue-900/70 text-blue-700 dark:text-blue-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                               >
                                 Add/Remove
                               </button>
@@ -2016,7 +2016,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                     updateType: UPDATE_TYPE.ABSOLUTE,
                                   })
                                 }
-                                className="flex-1 min-w-fit bg-purple-100 dark:bg-purple-900/50 hover:bg-purple-200 dark:hover:bg-purple-900/70 text-purple-700 dark:text-purple-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                                className="flex-1 min-w-20 bg-purple-100 dark:bg-purple-900/50 hover:bg-purple-200 dark:hover:bg-purple-900/70 text-purple-700 dark:text-purple-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                               >
                                   Set Qty
                               </button>
@@ -2029,7 +2029,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                     resource: resource,
                                   })
                                 }
-                                className="flex-1 min-w-fit bg-green-100 dark:bg-green-900/50 hover:bg-green-200 dark:hover:bg-green-900/70 text-green-700 dark:text-green-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                                className="flex-1 min-w-20 bg-green-100 dark:bg-green-900/50 hover:bg-green-200 dark:hover:bg-green-900/70 text-green-700 dark:text-green-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                               >
                                 Transfer
                               </button>
@@ -2041,7 +2041,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                       resource: resource,
                                     })
                                   }
-                                  className="flex-1 min-w-fit bg-orange-100 dark:bg-orange-900/50 hover:bg-orange-200 dark:hover:bg-orange-900/70 text-orange-700 dark:text-orange-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                                  className="flex-1 min-w-20 bg-orange-100 dark:bg-orange-900/50 hover:bg-orange-200 dark:hover:bg-orange-900/70 text-orange-700 dark:text-orange-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                                 >
                                   Set Target
                                 </button>
@@ -2053,7 +2053,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                               <div className="flex gap-1">
                                 <button
                                   onClick={() => startEditResource(resource)}
-                                  className="flex-1 min-w-fit bg-yellow-100 dark:bg-yellow-900/50 hover:bg-yellow-200 dark:hover:bg-yellow-900/70 text-yellow-700 dark:text-yellow-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                                  className="flex-1 min-w-20 bg-yellow-100 dark:bg-yellow-900/50 hover:bg-yellow-200 dark:hover:bg-yellow-900/70 text-yellow-700 dark:text-yellow-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                                 >
                                   Edit
                                 </button>
@@ -2065,7 +2065,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                       showDialog: true,
                                     })
                                   }
-                                  className="flex-1 min-w-fit bg-red-100 dark:bg-red-900/50 hover:bg-red-200 dark:hover:bg-red-900/70 text-red-700 dark:text-red-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
+                                  className="flex-1 min-w-20 bg-red-100 dark:bg-red-900/50 hover:bg-red-200 dark:hover:bg-red-900/70 text-red-700 dark:text-red-300 px-2 py-1 rounded-sm text-xs font-medium transition-colors"
                                 >
                                   Delete
                                 </button>

--- a/app/components/ResourceTable.tsx
+++ b/app/components/ResourceTable.tsx
@@ -1836,7 +1836,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
       {viewMode === VIEW_MODE.TABLE && (
         <div className="bg-white dark:bg-gray-800 shadow-xs rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
           <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 table-fixed">
               <thead className="bg-gray-50 dark:bg-gray-900">
                 <tr>
                   <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-1/4">


### PR DESCRIPTION
Replaces the inline text input for editing a resource's target quantity with a new modal-based approach.

In the `ResourceTable` component, the table view no longer shows a text box for the target. Instead, it displays the target quantity as plain text.

A new 'Set Target' button has been added for users with target editing permissions. This button is available in both the grid and table views, next to the 'Transfer' button.

Clicking 'Set Target' opens the new `ChangeTargetModal`, which allows the user to input a new target quantity and save it. The modal is styled consistently with other modals in the application.

This commit also includes the following changes:
- The "Set" button for quantity is now labeled "Set Qty".
- The "Set Target" button is now styled with an orange color.
- In the table view, the "Resource" column is narrower with text wrapping, and the "Actions" column is wider.
- The table layout is set to `table-fixed` to ensure column widths are respected.
- Action buttons in the table view have a `min-w-20` to ensure they have a sensible minimum width.