### PR TITLE
fix: Prevent filter overflow on smaller screens

### DIFF
--- a/app/components/ResourceTable.tsx
+++ b/app/components/ResourceTable.tsx
@@ -1387,7 +1387,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 border border-gray-200 dark:border-gray-700">
         <div className="flex flex-col gap-4">
           {/* Search and Filters Row */}
-          <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
+          <div className="flex flex-col sm:flex-row flex-wrap gap-4 items-start sm:items-center justify-between">
             {/* Search Bar */}
             <div className="relative flex-1 max-w-md">
               <svg
@@ -1464,7 +1464,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
           </div>
 
           {/* Filters Row */}
-          <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
+          <div className="flex flex-col sm:flex-row flex-wrap gap-4 items-start sm:items-center">
             {/* Status Filter */}
             <div className="flex items-center gap-2">
               <label className="text-sm font-medium text-gray-700 dark:text-gray-300">


### PR DESCRIPTION
Adds `flex-wrap` to the filter and search containers in `ResourceTable.tsx` to prevent the content from overflowing on screen widths between 640px and 1023px. The filters will now wrap to a new line when there is not enough horizontal space.