### PR TITLE
enter key to submit modals

### DIFF
--- a/app/components/ChangeTargetModal.tsx
+++ b/app/components/ChangeTargetModal.tsx
@@ -58,6 +58,13 @@ export function ChangeTargetModal({
     }
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSave()
+    }
+  }
+
   if (!showModal) return null
 
   return (
@@ -89,6 +96,7 @@ export function ChangeTargetModal({
               min="0"
               value={target}
               onChange={(e) => setTarget(Number(e.target.value) || 0)}
+              onKeyDown={handleKeyDown}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             />
           </div>

--- a/app/components/EditResourceModal.tsx
+++ b/app/components/EditResourceModal.tsx
@@ -82,6 +82,13 @@ export function EditResourceModal({ isOpen, onClose, onSave, resource }: EditRes
     }
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSave()
+    }
+  }
+
   if (!showModal || !resource) return null
 
   return (
@@ -120,6 +127,7 @@ export function EditResourceModal({ isOpen, onClose, onSave, resource }: EditRes
               type="text"
               value={formData.name}
               onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+              onKeyDown={handleKeyDown}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             />
           </div>
@@ -153,6 +161,7 @@ export function EditResourceModal({ isOpen, onClose, onSave, resource }: EditRes
               type="url"
               value={formData.imageUrl}
               onChange={(e) => setFormData({ ...formData, imageUrl: e.target.value })}
+              onKeyDown={handleKeyDown}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             />
           </div>
@@ -165,6 +174,7 @@ export function EditResourceModal({ isOpen, onClose, onSave, resource }: EditRes
               min="0"
               value={formData.multiplier}
               onChange={(e) => setFormData({ ...formData, multiplier: parseFloat(e.target.value) || 1.0 })}
+              onKeyDown={handleKeyDown}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             />
           </div>

--- a/app/components/TransferModal.tsx
+++ b/app/components/TransferModal.tsx
@@ -77,6 +77,13 @@ export function TransferModal({
     }
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleTransfer()
+    }
+  }
+
   if (!showModal) return null
 
   return (
@@ -108,6 +115,7 @@ export function TransferModal({
               min="1"
               value={amount}
               onChange={(e) => setAmount(parseInt(e.target.value) || 0)}
+              onKeyDown={handleKeyDown}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             />
           </div>

--- a/app/components/UpdateQuantityModal.tsx
+++ b/app/components/UpdateQuantityModal.tsx
@@ -73,6 +73,15 @@ export function UpdateQuantityModal({
     }
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      if (updateType === UPDATE_TYPE.ABSOLUTE) {
+        handleUpdate()
+      }
+    }
+  }
+
   const handleAdd = async () => {
     setError(null)
     if (amount <= 0) {
@@ -148,6 +157,7 @@ export function UpdateQuantityModal({
               onChange={(e) =>
                 setAmount(Math.max(0, parseInt(e.target.value) || 0))
               }
+              onKeyDown={handleKeyDown}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
               min="0"
             />


### PR DESCRIPTION

This functionality has been added to the edit, set quantity, set target, and transfer modals. I've added a function to each of these to detect when the "Enter" key is pressed and have attached this to the relevant input fields.

For the "set quantity" modal, this new behavior is only active when setting an absolute quantity, as you requested.