### PR TITLE
Address review comments on dependency update PR

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,9 +5,12 @@ import nextConfig from "eslint-config-next/core-web-vitals";
 // Its ScopeManager lacks addGlobals, which ESLint 10 requires. Replace it
 // with the TypeScript parser (already used for .ts/.tsx by a later entry)
 // and drop the Babel-specific parserOptions.
+let babelParserReplaced = false;
 const config = [
   ...nextConfig.map((entry) => {
-    if (entry.languageOptions?.parser?.meta?.name === "eslint-config-next/parser") {
+    const name = entry.languageOptions?.parser?.meta?.name;
+    if (name && /(?:eslint-config-next|next)\/parser/.test(name)) {
+      babelParserReplaced = true;
       const { parser: _babelParser, parserOptions: _babelOpts, ...restLangOpts } =
         entry.languageOptions;
       return {
@@ -31,5 +34,13 @@ const config = [
     },
   },
 ];
+
+if (!babelParserReplaced) {
+  throw new Error(
+    "eslint.config.mjs: expected to rewrite the bundled Babel/Next parser entry " +
+      "from eslint-config-next, but none matched /(?:eslint-config-next|next)\\/parser/. " +
+      "An eslint-config-next update may have changed the parser meta name — review the workaround.",
+  );
+}
 
 export default config;

--- a/lib/changelog.json
+++ b/lib/changelog.json
@@ -1,5 +1,5 @@
 {
-  "currentVersion": "4.1.5",
+  "currentVersion": "4.1.6",
   "releases": [
     {
       "version": "4.1.6",
@@ -9,7 +9,23 @@
       "changes": [
         {
           "type": "improvement",
-          "description": "Upgraded major dependencies: TypeScript 6.0, ESLint 10, lucide-react 1.x, drizzle-orm 0.45.2, and picomatch 2.3.2 security patch. Replaced the removed lucide-react Github branded icon with react-icons/fa FaGithub. Updated eslint-config-next to 16.2.4 for ESLint 10 compatibility."
+          "description": "Upgraded TypeScript from 5.9.3 to 6.0.2. Added types/vendor.d.ts to declare side-effect-only imports (@fontsource-variable/inter, *.css) now required by TypeScript 6."
+        },
+        {
+          "type": "improvement",
+          "description": "Upgraded ESLint from 9.39.4 to 10.1.0 and eslint-config-next from 15.5.14 to 16.2.4. Rewrote eslint.config.mjs to use eslint-config-next's native flat config, replacing the bundled Babel parser (incompatible with ESLint 10) with @typescript-eslint/parser."
+        },
+        {
+          "type": "improvement",
+          "description": "Upgraded lucide-react from 0.577.0 to 1.7.0. Replaced the removed Github branded icon with FaGithub from react-icons/fa."
+        },
+        {
+          "type": "improvement",
+          "description": "Upgraded drizzle-orm from 0.45.1 to 0.45.2."
+        },
+        {
+          "type": "improvement",
+          "description": "Applied picomatch 2.3.2 security patch via npm overrides."
         }
       ]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resource-tracker",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resource-tracker",
-      "version": "4.1.5",
+      "version": "4.1.6",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@headlessui/react": "^2.2.9",
@@ -48,7 +48,8 @@
         "prettier-plugin-tailwindcss": "^0.7.2",
         "tailwindcss": "^4.2.2",
         "tsx": "^4.21.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.2",
+        "typescript-eslint": "^8.46.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-tracker",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -67,6 +67,7 @@
     "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^4.2.2",
     "tsx": "^4.21.0",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "typescript-eslint": "^8.46.0"
   }
 }

--- a/types/vendor.d.ts
+++ b/types/vendor.d.ts
@@ -1,2 +1,8 @@
 declare module "@fontsource-variable/inter";
+
+// TypeScript 6 requires declarations for side-effect-only CSS imports.
+// next/types/global.d.ts already declares "*.module.css" with typed exports,
+// and TypeScript selects the longest-matching wildcard pattern, so that
+// declaration takes precedence for any CSS Module file — this catch-all only
+// applies to plain side-effect CSS imports like globals.css.
 declare module "*.css";


### PR DESCRIPTION
- eslint.config.mjs: switch strict equality on parser meta name to /(?:eslint-config-next|next)\/parser/ regex for resilience; add startup assertion that throws if no entry was rewritten, so a future eslint-config-next rename fails loudly rather than silently
- package.json: add typescript-eslint ^8.46.0 to devDependencies so the direct import in eslint.config.mjs resolves deterministically (it was previously only a transitive dep via eslint-config-next)
- package.json / changelog.json: bump version 4.1.5 → 4.1.6 and currentVersion to match, so shouldShowChangelog() surfaces the new release in WhatsNewModal
- changelog.json: split the single bundled improvement entry into separate entries per upgrade (TypeScript, ESLint, lucide-react, drizzle-orm, picomatch)
- types/vendor.d.ts: add comment explaining why declare module "*.css" is safe — next/types/global.d.ts already declares "*.module.css" with typed exports; TypeScript's longest-wildcard-match rule ensures that declaration takes precedence for CSS Module files

https://claude.ai/code/session_01PZjHWNNXLzAJAJgnxc4UjX