### PR TITLE
feat: dual-write and location-agnostic fallback for resources, histor…

### DIFF
--- a/app/api/global-settings/route.ts
+++ b/app/api/global-settings/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getLocationNames } from "@/lib/global-settings";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/global-settings
+ *
+ * Returns the configured display names for the two inventory locations.
+ * Falls back to "Hagga" / "Deep Desert" when the settings are missing.
+ *
+ * Requires an authenticated session.
+ */
+export async function GET(_request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { location1Name, location2Name } = await getLocationNames();
+    return NextResponse.json(
+      { location1Name, location2Name },
+      {
+        headers: {
+          "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+          Pragma: "no-cache",
+          Expires: "0",
+        },
+      },
+    );
+  } catch (error) {
+    console.error("Error fetching global settings:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch global settings" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/internal/leaderboard/route.ts
+++ b/app/api/internal/leaderboard/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getLeaderboard } from "@/lib/leaderboard";
+import { mapCategoryForRead } from "@/lib/resource-mapping";
 
 export const dynamic = "force-dynamic";
 
@@ -33,8 +34,14 @@ export async function GET(request: NextRequest) {
 
     const result = await getLeaderboard(timeFilter, effectiveLimit, offset);
 
+    const mappedRankings = result.rankings.map((entry: any) =>
+      entry && typeof entry === "object" && "resourceCategory" in entry
+        ? { ...entry, resourceCategory: mapCategoryForRead(entry.resourceCategory) }
+        : entry,
+    );
+
     return NextResponse.json({
-      leaderboard: result.rankings,
+      leaderboard: mappedRankings,
       timeFilter,
       total: result.total,
       page,

--- a/app/api/internal/resources/[id]/history/route.ts
+++ b/app/api/internal/resources/[id]/history/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db, resourceHistory } from "@/lib/db";
 import { eq, gte, desc, and } from "drizzle-orm";
+import { mapHistoryRowForRead } from "@/lib/resource-mapping";
 
 export const dynamic = "force-dynamic";
 
@@ -11,6 +12,10 @@ export const dynamic = "force-dynamic";
  * filtered to the last `days` days (default: 7). Results are ordered
  * newest-first. Intended to be called only by the authenticated
  * `GET /api/resources/[id]/history` proxy. Marked `force-dynamic`.
+ *
+ * Applies fallback mapping so location-agnostic tracking columns fall back to
+ * their legacy Hagga/Deep Desert counterparts, and legacy `transferDirection`
+ * strings are translated to their `transfer_to_location_{1,2}` equivalents.
  */
 export async function GET(
   request: NextRequest,
@@ -38,7 +43,7 @@ export async function GET(
       .orderBy(desc(resourceHistory.createdAt))
       .limit(100); // Limit to reduce load
 
-    return NextResponse.json(history);
+    return NextResponse.json(history.map(mapHistoryRowForRead));
   } catch (error) {
     console.error("Error fetching resource history:", error);
     return NextResponse.json(

--- a/app/api/internal/resources/route.ts
+++ b/app/api/internal/resources/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db, resources } from "@/lib/db";
+import { mapResourceRowForRead } from "@/lib/resource-mapping";
 
 export const dynamic = "force-dynamic";
 
@@ -10,12 +11,16 @@ export const dynamic = "force-dynamic";
  * database. Intended to be called only by the public-facing
  * `GET /api/resources` route (which handles auth). Marked
  * `force-dynamic` to opt out of Next.js static caching.
+ *
+ * Applies fallback mapping so location-agnostic quantity fields fall back to
+ * their legacy Hagga/Deep Desert counterparts, and the legacy "Blueprints"
+ * category is returned as "Gear Blueprints".
  */
 export async function GET(request: NextRequest) {
   try {
     const allResources = await db.select().from(resources);
 
-    return NextResponse.json(allResources);
+    return NextResponse.json(allResources.map(mapResourceRowForRead));
   } catch (error) {
     console.error("Error fetching resources:", error);
     return NextResponse.json(

--- a/app/api/internal/user/activity/route.ts
+++ b/app/api/internal/user/activity/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db, resourceHistory, resources } from "@/lib/db";
 import { eq, gte, desc, and, or } from "drizzle-orm";
+import {
+  mapCategoryForRead,
+  mapTransferDirectionForRead,
+} from "@/lib/resource-mapping";
 
 export const dynamic = "force-dynamic";
 
@@ -53,6 +57,12 @@ export async function GET(request: NextRequest) {
         previousQuantityDeepDesert: resourceHistory.previousQuantityDeepDesert,
         newQuantityDeepDesert: resourceHistory.newQuantityDeepDesert,
         changeAmountDeepDesert: resourceHistory.changeAmountDeepDesert,
+        previousQuantityLocation1: resourceHistory.previousQuantityLocation1,
+        newQuantityLocation1: resourceHistory.newQuantityLocation1,
+        changeAmountLocation1: resourceHistory.changeAmountLocation1,
+        previousQuantityLocation2: resourceHistory.previousQuantityLocation2,
+        newQuantityLocation2: resourceHistory.newQuantityLocation2,
+        changeAmountLocation2: resourceHistory.changeAmountLocation2,
         transferAmount: resourceHistory.transferAmount,
         transferDirection: resourceHistory.transferDirection,
         changeType: resourceHistory.changeType,
@@ -84,6 +94,22 @@ export async function GET(request: NextRequest) {
         (entry.changeAmountHagga || 0) + (entry.changeAmountDeepDesert || 0);
       return {
         ...entry,
+        resourceCategory: mapCategoryForRead(entry.resourceCategory),
+        previousQuantityLocation1:
+          entry.previousQuantityLocation1 ?? entry.previousQuantityHagga ?? null,
+        newQuantityLocation1:
+          entry.newQuantityLocation1 ?? entry.newQuantityHagga ?? null,
+        changeAmountLocation1:
+          entry.changeAmountLocation1 ?? entry.changeAmountHagga ?? null,
+        previousQuantityLocation2:
+          entry.previousQuantityLocation2 ??
+          entry.previousQuantityDeepDesert ??
+          null,
+        newQuantityLocation2:
+          entry.newQuantityLocation2 ?? entry.newQuantityDeepDesert ?? null,
+        changeAmountLocation2:
+          entry.changeAmountLocation2 ?? entry.changeAmountDeepDesert ?? null,
+        transferDirection: mapTransferDirectionForRead(entry.transferDirection),
         changeAmount: totalChangeAmount,
       };
     });

--- a/app/api/leaderboard/[userId]/route.ts
+++ b/app/api/leaderboard/[userId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getUserContributions, getUserRank } from "@/lib/leaderboard";
+import { mapCategoryForRead } from "@/lib/resource-mapping";
 
 /**
  * GET /api/leaderboard/[userId]
@@ -40,12 +41,18 @@ export async function GET(
       getUserRank(userId, timeFilter),
     ]);
 
+    const mappedContributions = contributions.contributions.map((entry: any) =>
+      entry && typeof entry === "object" && "resourceCategory" in entry
+        ? { ...entry, resourceCategory: mapCategoryForRead(entry.resourceCategory) }
+        : entry,
+    );
+
     return NextResponse.json(
       {
         userId: userId,
         timeFilter,
         rank,
-        contributions: contributions.contributions,
+        contributions: mappedContributions,
         summary: contributions.summary,
         total: contributions.total,
         page,

--- a/app/api/resources/[id]/route.ts
+++ b/app/api/resources/[id]/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/discord-roles";
 import { awardPoints } from "@/lib/leaderboard";
 import { calculateResourceStatus } from "@/lib/resource-utils";
+import { mapCategoryForRead, mapResourceRowForRead } from "@/lib/resource-mapping";
 
 /**
  * PUT /api/resources/[id]
@@ -60,8 +61,20 @@ export async function PUT(
       reason = reason.trim().replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, '');
     }
 
-    if (quantityField !== undefined && quantityField !== "quantityHagga" && quantityField !== "quantityDeepDesert") {
-      return NextResponse.json({ error: "quantityField must be 'quantityHagga' or 'quantityDeepDesert'" }, { status: 400 });
+    if (
+      quantityField !== undefined &&
+      quantityField !== "quantityHagga" &&
+      quantityField !== "quantityDeepDesert" &&
+      quantityField !== "quantityLocation1" &&
+      quantityField !== "quantityLocation2"
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "quantityField must be 'quantityHagga', 'quantityDeepDesert', 'quantityLocation1', or 'quantityLocation2'",
+        },
+        { status: 400 },
+      );
     }
 
     if (updateType === "absolute") {
@@ -128,7 +141,10 @@ export async function PUT(
       let newQuantityDeepDesert = resource.quantityDeepDesert;
       let changeAmountDeepDesert = 0;
 
-      if (quantityField === "quantityDeepDesert") {
+      if (
+        quantityField === "quantityDeepDesert" ||
+        quantityField === "quantityLocation2"
+      ) {
         changeAmountDeepDesert =
           updateType === "relative"
             ? changeValue
@@ -136,7 +152,7 @@ export async function PUT(
         newQuantityDeepDesert =
           previousQuantityDeepDesert + changeAmountDeepDesert;
       } else {
-        // default to hagga
+        // default to location 1 (legacy: hagga)
         changeAmountHagga =
           updateType === "relative"
             ? changeValue
@@ -144,18 +160,20 @@ export async function PUT(
         newQuantityHagga = previousQuantityHagga + changeAmountHagga;
       }
 
-      // Update the resource
+      // Update the resource (dual-write to legacy + location-agnostic columns)
       await tx
         .update(resources)
         .set({
           quantityHagga: newQuantityHagga,
           quantityDeepDesert: newQuantityDeepDesert,
+          quantityLocation1: newQuantityHagga,
+          quantityLocation2: newQuantityDeepDesert,
           lastUpdatedBy: actingUserIdentifier, // Always log the admin who performed the action
           updatedAt: new Date(),
         })
         .where(eq(resources.id, id));
 
-      // Log the change in history
+      // Log the change in history (dual-write to legacy + location-agnostic columns)
       await tx.insert(resourceHistory).values({
         id: nanoid(),
         resourceId: id,
@@ -165,6 +183,12 @@ export async function PUT(
         previousQuantityDeepDesert,
         newQuantityDeepDesert,
         changeAmountDeepDesert,
+        previousQuantityLocation1: previousQuantityHagga,
+        newQuantityLocation1: newQuantityHagga,
+        changeAmountLocation1: changeAmountHagga,
+        previousQuantityLocation2: previousQuantityDeepDesert,
+        newQuantityLocation2: newQuantityDeepDesert,
+        changeAmountLocation2: changeAmountDeepDesert,
         changeType: updateType || "absolute",
         updatedBy: effectiveUserId, // This is the user the action is for
         reason: reason,
@@ -194,7 +218,7 @@ export async function PUT(
           Math.abs(totalChangeAmount),
           {
             name: resource.name,
-            category: resource.category || "Other",
+            category: mapCategoryForRead(resource.category) || "Other",
             status: resourceStatus,
             multiplier: resource.multiplier || 1.0,
           },
@@ -208,7 +232,9 @@ export async function PUT(
         .where(eq(resources.id, id));
 
       return {
-        resource: updatedResource[0],
+        resource: updatedResource[0]
+          ? mapResourceRowForRead(updatedResource[0])
+          : updatedResource[0],
         pointsEarned: pointsCalculation?.finalPoints || 0,
         pointsCalculation,
       };

--- a/app/api/resources/[id]/transfer/route.ts
+++ b/app/api/resources/[id]/transfer/route.ts
@@ -6,14 +6,21 @@ import { resources, resourceHistory } from "@/lib/db";
 import { eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { hasResourceAccess } from "@/lib/discord-roles";
+import { mapResourceRowForRead } from "@/lib/resource-mapping";
 
 /**
  * PUT /api/resources/[id]/transfer
  *
- * Transfers a quantity of a resource between the Hagga base and Deep Desert
- * storage. The transfer direction is specified by `transferDirection`:
- * - `"to_deep_desert"` — moves units from Hagga → Deep Desert
- * - `"to_hagga"` — moves units from Deep Desert → Hagga
+ * Transfers a quantity of a resource between the two inventory locations.
+ * Accepts either the legacy direction strings or their location-agnostic
+ * equivalents:
+ * - `"to_deep_desert"` / `"transfer_to_location_2"` — moves units from
+ *   location 1 (legacy: Hagga) → location 2 (legacy: Deep Desert)
+ * - `"to_hagga"` / `"transfer_to_location_1"` — moves units from location 2 →
+ *   location 1
+ *
+ * History entries are written using the new `transfer_to_location_{1,2}`
+ * direction strings.
  *
  * Validates that the source location has sufficient stock, then atomically
  * updates both quantities and logs the transfer in resource history.
@@ -46,10 +53,19 @@ export async function PUT(
       );
     }
 
-    if (
-      transferDirection !== "to_deep_desert" &&
-      transferDirection !== "to_hagga"
-    ) {
+    const TO_LOCATION_2_DIRECTIONS = new Set([
+      "to_deep_desert",
+      "transfer_to_location_2",
+    ]);
+    const TO_LOCATION_1_DIRECTIONS = new Set([
+      "to_hagga",
+      "transfer_to_location_1",
+    ]);
+
+    const isToLocation2 = TO_LOCATION_2_DIRECTIONS.has(transferDirection);
+    const isToLocation1 = TO_LOCATION_1_DIRECTIONS.has(transferDirection);
+
+    if (!isToLocation1 && !isToLocation2) {
       return NextResponse.json(
         { error: "Invalid transferDirection" },
         { status: 400 },
@@ -69,14 +85,13 @@ export async function PUT(
       let newQuantityHagga = resource.quantityHagga;
       let newQuantityDeepDesert = resource.quantityDeepDesert;
 
-      if (transferDirection === "to_deep_desert") {
+      if (isToLocation2) {
         if (resource.quantityHagga < transferAmount) {
           throw new Error("Insufficient quantity in Hagga base");
         }
         newQuantityHagga = resource.quantityHagga - transferAmount;
         newQuantityDeepDesert = resource.quantityDeepDesert + transferAmount;
       } else {
-        // to_hagga
         if (resource.quantityDeepDesert < transferAmount) {
           throw new Error("Insufficient quantity in Deep Desert base");
         }
@@ -89,37 +104,53 @@ export async function PUT(
         .set({
           quantityHagga: newQuantityHagga,
           quantityDeepDesert: newQuantityDeepDesert,
+          quantityLocation1: newQuantityHagga,
+          quantityLocation2: newQuantityDeepDesert,
           lastUpdatedBy: userId,
           updatedAt: new Date(),
         })
         .where(eq(resources.id, id));
+
+      const changeAmountHagga = isToLocation1 ? transferAmount : -transferAmount;
+      const changeAmountDeepDesert = isToLocation2
+        ? transferAmount
+        : -transferAmount;
+      const newTransferDirection = isToLocation2
+        ? "transfer_to_location_2"
+        : "transfer_to_location_1";
 
       await tx.insert(resourceHistory).values({
         id: nanoid(),
         resourceId: id,
         previousQuantityHagga: resource.quantityHagga,
         newQuantityHagga: newQuantityHagga,
-        changeAmountHagga:
-          transferDirection === "to_hagga" ? transferAmount : -transferAmount,
+        changeAmountHagga,
         previousQuantityDeepDesert: resource.quantityDeepDesert,
         newQuantityDeepDesert: newQuantityDeepDesert,
-        changeAmountDeepDesert:
-          transferDirection === "to_deep_desert"
-            ? transferAmount
-            : -transferAmount,
+        changeAmountDeepDesert,
+        previousQuantityLocation1: resource.quantityHagga,
+        newQuantityLocation1: newQuantityHagga,
+        changeAmountLocation1: changeAmountHagga,
+        previousQuantityLocation2: resource.quantityDeepDesert,
+        newQuantityLocation2: newQuantityDeepDesert,
+        changeAmountLocation2: changeAmountDeepDesert,
         changeType: "transfer",
         updatedBy: userId,
-        reason: `Transfer ${transferAmount} ${transferDirection}`,
+        reason: `Transfer ${transferAmount} ${newTransferDirection}`,
         createdAt: new Date(),
         transferAmount: transferAmount,
-        transferDirection: transferDirection,
+        transferDirection: newTransferDirection,
       });
 
       const updatedResource = await tx
         .select()
         .from(resources)
         .where(eq(resources.id, id));
-      return { resource: updatedResource[0] };
+      return {
+        resource: updatedResource[0]
+          ? mapResourceRowForRead(updatedResource[0])
+          : updatedResource[0],
+      };
     });
 
     return NextResponse.json(result, {

--- a/app/api/resources/bulk/confirm/route.ts
+++ b/app/api/resources/bulk/confirm/route.ts
@@ -87,22 +87,34 @@ export async function POST(request: NextRequest) {
           .set({
             quantityHagga: update.new.quantityHagga,
             quantityDeepDesert: update.new.quantityDeepDesert,
+            quantityLocation1: update.new.quantityHagga,
+            quantityLocation2: update.new.quantityDeepDesert,
             targetQuantity: update.new.targetQuantity,
             lastUpdatedBy: userId,
             updatedAt: new Date(),
           })
           .where(eq(resources.id, update.id));
 
+        const changeAmountHagga =
+          update.new.quantityHagga - current.quantityHagga;
+        const changeAmountDeepDesert =
+          update.new.quantityDeepDesert - current.quantityDeepDesert;
+
         await tx.insert(resourceHistory).values({
           id: nanoid(),
           resourceId: update.id,
           previousQuantityHagga: current.quantityHagga,
           newQuantityHagga: update.new.quantityHagga,
-          changeAmountHagga: update.new.quantityHagga - current.quantityHagga,
+          changeAmountHagga,
           previousQuantityDeepDesert: current.quantityDeepDesert,
           newQuantityDeepDesert: update.new.quantityDeepDesert,
-          changeAmountDeepDesert:
-            update.new.quantityDeepDesert - current.quantityDeepDesert,
+          changeAmountDeepDesert,
+          previousQuantityLocation1: current.quantityHagga,
+          newQuantityLocation1: update.new.quantityHagga,
+          changeAmountLocation1: changeAmountHagga,
+          previousQuantityLocation2: current.quantityDeepDesert,
+          newQuantityLocation2: update.new.quantityDeepDesert,
+          changeAmountLocation2: changeAmountDeepDesert,
           changeType: "absolute",
           updatedBy: userId,
           reason: "Bulk CSV import",

--- a/app/api/resources/route.ts
+++ b/app/api/resources/route.ts
@@ -7,6 +7,7 @@ import { hasResourceAccess, hasResourceAdminAccess } from "@/lib/discord-roles";
 import { nanoid } from "nanoid";
 import { awardPoints } from "@/lib/leaderboard";
 import { calculateResourceStatus } from "@/lib/resource-utils";
+import { mapCategoryForRead } from "@/lib/resource-mapping";
 
 /**
  * GET /api/resources
@@ -92,6 +93,8 @@ export async function POST(request: NextRequest) {
       quantity,
       quantityHagga,
       quantityDeepDesert,
+      quantityLocation1,
+      quantityLocation2,
       targetQuantity,
       multiplier,
     } = await request.json();
@@ -104,14 +107,16 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const haggaQty = quantityHagga || quantity || 0;
-    const deepDesertQty = quantityDeepDesert || 0;
+    const location1Qty = quantityLocation1 ?? quantityHagga ?? quantity ?? 0;
+    const location2Qty = quantityLocation2 ?? quantityDeepDesert ?? 0;
 
     const newResource = {
       id: nanoid(),
       name,
-      quantityHagga: haggaQty,
-      quantityDeepDesert: deepDesertQty,
+      quantityHagga: location1Qty,
+      quantityDeepDesert: location2Qty,
+      quantityLocation1: location1Qty,
+      quantityLocation2: location2Qty,
       description: description || null,
       category,
       subcategory: subcategory || null,
@@ -131,7 +136,7 @@ export async function POST(request: NextRequest) {
         .values(newResource)
         .returning();
 
-      // Log the creation in history
+      // Log the creation in history (dual-write to legacy + location-agnostic columns)
       await tx.insert(resourceHistory).values({
         id: nanoid(),
         resourceId: inserted[0].id,
@@ -141,6 +146,12 @@ export async function POST(request: NextRequest) {
         previousQuantityDeepDesert: 0,
         newQuantityDeepDesert: inserted[0].quantityDeepDesert,
         changeAmountDeepDesert: inserted[0].quantityDeepDesert,
+        previousQuantityLocation1: 0,
+        newQuantityLocation1: inserted[0].quantityHagga,
+        changeAmountLocation1: inserted[0].quantityHagga,
+        previousQuantityLocation2: 0,
+        newQuantityLocation2: inserted[0].quantityDeepDesert,
+        changeAmountLocation2: inserted[0].quantityDeepDesert,
         changeType: "absolute",
         updatedBy: userId,
         reason: "Resource created",
@@ -300,6 +311,7 @@ export async function PUT(request: NextRequest) {
             .update(resources)
             .set({
               quantityHagga: update.quantity,
+              quantityLocation1: update.quantity,
               lastUpdatedBy: userId,
               updatedAt: new Date(),
             })
@@ -314,6 +326,12 @@ export async function PUT(request: NextRequest) {
             previousQuantityDeepDesert: resource.quantityDeepDesert,
             newQuantityDeepDesert: resource.quantityDeepDesert, // unchanged
             changeAmountDeepDesert: 0,
+            previousQuantityLocation1: previousQuantityHagga,
+            newQuantityLocation1: update.quantity,
+            changeAmountLocation1: changeAmountHagga,
+            previousQuantityLocation2: resource.quantityDeepDesert,
+            newQuantityLocation2: resource.quantityDeepDesert,
+            changeAmountLocation2: 0,
             changeType: update.updateType,
             updatedBy: userId,
             reason: update.reason,
@@ -335,7 +353,7 @@ export async function PUT(request: NextRequest) {
               Math.abs(changeAmountHagga),
               {
                 name: resource.name,
-                category: resource.category || "Other",
+                category: mapCategoryForRead(resource.category) || "Other",
                 status: calculateResourceStatus(
                   resource.quantityHagga + resource.quantityDeepDesert,
                   resource.targetQuantity,

--- a/lib/changelog.json
+++ b/lib/changelog.json
@@ -22,6 +22,18 @@
         {
           "type": "feature",
           "description": "Added quantityLocation1 and quantityLocation2 columns to the resources table and six corresponding history columns to resource_history via a new Drizzle migration."
+        },
+        {
+          "type": "feature",
+          "description": "Added GET /api/global-settings and getLocationNames() utility to read configurable inventory location display names from the global_settings table (keys inventory_location_1_name / inventory_location_2_name), falling back to 'Hagga' / 'Deep Desert'."
+        },
+        {
+          "type": "feature",
+          "description": "Resource, history, leaderboard, and user activity APIs now dual-write to legacy Hagga/Deep Desert and new Location1/Location2 columns, and dual-read with Location* fields falling back to their Hagga/Deep Desert counterparts."
+        },
+        {
+          "type": "feature",
+          "description": "Leaderboard and user activity reads translate the legacy 'Blueprints' category to 'Gear Blueprints', and awardPoints() now persists the new category explicitly. Resource history and transfers translate legacy transferDirection values ('to_hagga', 'to_deep_desert') to their 'transfer_to_location_{1,2}' equivalents; transfers accept both the legacy and new direction strings on write."
         }
       ]
     },

--- a/lib/global-settings.ts
+++ b/lib/global-settings.ts
@@ -1,0 +1,59 @@
+import { db, globalSettings } from "./db";
+import { inArray } from "drizzle-orm";
+
+export const LOCATION_1_NAME_KEY = "inventory_location_1_name";
+export const LOCATION_2_NAME_KEY = "inventory_location_2_name";
+
+export const DEFAULT_LOCATION_1_NAME = "Hagga";
+export const DEFAULT_LOCATION_2_NAME = "Deep Desert";
+
+export interface LocationNames {
+  location1Name: string;
+  location2Name: string;
+}
+
+/**
+ * Read the configured display names for the two inventory locations from the
+ * global_settings table. Falls back to "Hagga" / "Deep Desert" when the keys
+ * are missing, null, or empty.
+ */
+export async function getLocationNames(
+  dbInstance: any = db,
+): Promise<LocationNames> {
+  try {
+    const rows = await dbInstance
+      .select()
+      .from(globalSettings)
+      .where(
+        inArray(globalSettings.settingKey, [
+          LOCATION_1_NAME_KEY,
+          LOCATION_2_NAME_KEY,
+        ]),
+      );
+
+    const byKey = new Map<string, string | null | undefined>();
+    for (const row of rows) {
+      byKey.set(row.settingKey, row.settingValue);
+    }
+
+    const rawLoc1 = byKey.get(LOCATION_1_NAME_KEY);
+    const rawLoc2 = byKey.get(LOCATION_2_NAME_KEY);
+
+    const location1Name =
+      typeof rawLoc1 === "string" && rawLoc1.trim().length > 0
+        ? rawLoc1
+        : DEFAULT_LOCATION_1_NAME;
+    const location2Name =
+      typeof rawLoc2 === "string" && rawLoc2.trim().length > 0
+        ? rawLoc2
+        : DEFAULT_LOCATION_2_NAME;
+
+    return { location1Name, location2Name };
+  } catch (error) {
+    console.error("Error fetching location names from global_settings:", error);
+    return {
+      location1Name: DEFAULT_LOCATION_1_NAME,
+      location2Name: DEFAULT_LOCATION_2_NAME,
+    };
+  }
+}

--- a/lib/leaderboard.ts
+++ b/lib/leaderboard.ts
@@ -1,6 +1,7 @@
 import { db, leaderboard, resources } from "./db";
 import { eq, desc, sql, and, gte } from "drizzle-orm";
 import { nanoid } from "nanoid";
+import { mapCategoryForRead } from "./resource-mapping";
 
 // Constants for points calculation
 const BASE_POINTS_PER_1000_RESOURCES = 100;
@@ -116,12 +117,17 @@ export async function awardPoints(
   },
   dbInstance: any = db,
 ): Promise<PointsCalculation> {
+  // Normalize legacy category strings before persisting — the leaderboard
+  // always stores the new location/role-agnostic category names.
+  const normalizedCategory =
+    mapCategoryForRead(resourceData.category) ?? resourceData.category;
+
   const calculation = calculatePoints(
     actionType,
     quantityChanged,
     resourceData.multiplier,
     resourceData.status,
-    resourceData.category,
+    normalizedCategory,
   );
 
   // Only create leaderboard entry if points were earned
@@ -137,7 +143,7 @@ export async function awardPoints(
       statusBonus: calculation.statusBonus,
       finalPoints: calculation.finalPoints,
       resourceName: resourceData.name,
-      resourceCategory: resourceData.category,
+      resourceCategory: normalizedCategory,
       resourceStatus: resourceData.status,
       createdAt: new Date(),
     });

--- a/lib/resource-mapping.ts
+++ b/lib/resource-mapping.ts
@@ -1,0 +1,128 @@
+/**
+ * Helpers for normalizing resource / resource-history rows between the legacy
+ * (Hagga / Deep Desert) and location-agnostic (Location1 / Location2) schemas.
+ *
+ * During the migration we dual-write to both sets of columns. These helpers
+ * provide fallback reads so consumers always see populated location-agnostic
+ * values, and translate the legacy category/direction strings to their new
+ * location-agnostic equivalents.
+ */
+
+export const LEGACY_CATEGORY_BLUEPRINTS = "Blueprints";
+export const NEW_CATEGORY_GEAR_BLUEPRINTS = "Gear Blueprints";
+
+export const LEGACY_DIRECTION_TO_HAGGA = "to_hagga";
+export const LEGACY_DIRECTION_TO_DEEP_DESERT = "to_deep_desert";
+export const NEW_DIRECTION_TO_LOCATION_1 = "transfer_to_location_1";
+export const NEW_DIRECTION_TO_LOCATION_2 = "transfer_to_location_2";
+
+/**
+ * Maps the legacy category string "Blueprints" to "Gear Blueprints". Leaves
+ * other values (including nullish) untouched.
+ */
+export function mapCategoryForRead<T extends string | null | undefined>(
+  category: T,
+): T | typeof NEW_CATEGORY_GEAR_BLUEPRINTS {
+  if (category === LEGACY_CATEGORY_BLUEPRINTS) {
+    return NEW_CATEGORY_GEAR_BLUEPRINTS;
+  }
+  return category;
+}
+
+/**
+ * Maps the legacy transfer direction strings to the new location-agnostic
+ * equivalents. Leaves other values (including nullish) untouched.
+ */
+export function mapTransferDirectionForRead<T extends string | null | undefined>(
+  direction: T,
+): T | typeof NEW_DIRECTION_TO_LOCATION_1 | typeof NEW_DIRECTION_TO_LOCATION_2 {
+  if (direction === LEGACY_DIRECTION_TO_HAGGA) {
+    return NEW_DIRECTION_TO_LOCATION_1;
+  }
+  if (direction === LEGACY_DIRECTION_TO_DEEP_DESERT) {
+    return NEW_DIRECTION_TO_LOCATION_2;
+  }
+  return direction;
+}
+
+type ResourceRowShape = {
+  quantityHagga?: number | null;
+  quantityDeepDesert?: number | null;
+  quantityLocation1?: number | null;
+  quantityLocation2?: number | null;
+  category?: string | null;
+  [key: string]: unknown;
+};
+
+/**
+ * Returns a resource row augmented with location-agnostic quantity fields
+ * (falling back to the legacy Hagga / Deep Desert columns when the new columns
+ * are null/undefined) and with the legacy "Blueprints" category translated to
+ * "Gear Blueprints".
+ */
+export function mapResourceRowForRead<T extends ResourceRowShape>(
+  row: T,
+): T & { quantityLocation1: number; quantityLocation2: number } {
+  const quantityLocation1 =
+    row.quantityLocation1 ?? row.quantityHagga ?? 0;
+  const quantityLocation2 =
+    row.quantityLocation2 ?? row.quantityDeepDesert ?? 0;
+  const category = mapCategoryForRead(row.category ?? null);
+
+  return {
+    ...row,
+    quantityLocation1,
+    quantityLocation2,
+    category,
+  } as T & { quantityLocation1: number; quantityLocation2: number };
+}
+
+type HistoryRowShape = {
+  previousQuantityHagga?: number | null;
+  newQuantityHagga?: number | null;
+  changeAmountHagga?: number | null;
+  previousQuantityDeepDesert?: number | null;
+  newQuantityDeepDesert?: number | null;
+  changeAmountDeepDesert?: number | null;
+  previousQuantityLocation1?: number | null;
+  newQuantityLocation1?: number | null;
+  changeAmountLocation1?: number | null;
+  previousQuantityLocation2?: number | null;
+  newQuantityLocation2?: number | null;
+  changeAmountLocation2?: number | null;
+  transferDirection?: string | null;
+  [key: string]: unknown;
+};
+
+/**
+ * Returns a resource_history row with location-agnostic quantity tracking
+ * fields populated from their legacy Hagga/Deep Desert counterparts when
+ * missing, and with the transferDirection translated to the new
+ * `transfer_to_location_{1,2}` values.
+ */
+export function mapHistoryRowForRead<T extends HistoryRowShape>(
+  row: T,
+): T & {
+  previousQuantityLocation1: number | null;
+  newQuantityLocation1: number | null;
+  changeAmountLocation1: number | null;
+  previousQuantityLocation2: number | null;
+  newQuantityLocation2: number | null;
+  changeAmountLocation2: number | null;
+} {
+  return {
+    ...row,
+    previousQuantityLocation1:
+      row.previousQuantityLocation1 ?? row.previousQuantityHagga ?? null,
+    newQuantityLocation1: row.newQuantityLocation1 ?? row.newQuantityHagga ?? null,
+    changeAmountLocation1:
+      row.changeAmountLocation1 ?? row.changeAmountHagga ?? null,
+    previousQuantityLocation2:
+      row.previousQuantityLocation2 ?? row.previousQuantityDeepDesert ?? null,
+    newQuantityLocation2:
+      row.newQuantityLocation2 ?? row.newQuantityDeepDesert ?? null,
+    changeAmountLocation2:
+      row.changeAmountLocation2 ?? row.changeAmountDeepDesert ?? null,
+    transferDirection: mapTransferDirectionForRead(row.transferDirection ?? null),
+  };
+}

--- a/tests/api/global-settings/route.test.ts
+++ b/tests/api/global-settings/route.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+jest.mock("next-auth");
+
+describe("GET /api/global-settings", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const { getServerSession } = require("next-auth");
+    getServerSession.mockResolvedValueOnce(null);
+
+    jest.doMock("@/lib/global-settings", () => ({
+      getLocationNames: jest.fn(),
+    }));
+
+    const { GET } = await import("@/app/api/global-settings/route");
+    const request = new NextRequest("http://localhost/api/global-settings");
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns configured location names", async () => {
+    const { getServerSession } = require("next-auth");
+    getServerSession.mockResolvedValueOnce({ user: { id: "u" } });
+
+    const mockGetLocationNames = jest.fn().mockResolvedValue({
+      location1Name: "Arrakeen",
+      location2Name: "Sietch Tabr",
+    });
+    jest.doMock("@/lib/global-settings", () => ({
+      getLocationNames: mockGetLocationNames,
+    }));
+
+    const { GET } = await import("@/app/api/global-settings/route");
+    const request = new NextRequest("http://localhost/api/global-settings");
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      location1Name: "Arrakeen",
+      location2Name: "Sietch Tabr",
+    });
+    expect(mockGetLocationNames).toHaveBeenCalled();
+  });
+
+  it("returns 500 on failure", async () => {
+    const { getServerSession } = require("next-auth");
+    getServerSession.mockResolvedValueOnce({ user: { id: "u" } });
+
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    jest.doMock("@/lib/global-settings", () => ({
+      getLocationNames: jest.fn().mockRejectedValue(new Error("boom")),
+    }));
+
+    const { GET } = await import("@/app/api/global-settings/route");
+    const request = new NextRequest("http://localhost/api/global-settings");
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({ error: "Failed to fetch global settings" });
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/tests/api/internal/resources/[id]/history/route.test.ts
+++ b/tests/api/internal/resources/[id]/history/route.test.ts
@@ -37,8 +37,65 @@ describe("GET /api/internal/resources/[id]/history", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body).toEqual(mockHistory);
+    // GET augments each history row with location-agnostic quantity fields
+    // (falling back to the legacy Hagga/Deep Desert columns, which are absent
+    // here -> null) and a null transferDirection.
+    expect(body).toEqual([
+      expect.objectContaining({
+        id: "1",
+        resourceId: "123",
+        previousQuantityLocation1: null,
+        newQuantityLocation1: null,
+        changeAmountLocation1: null,
+        previousQuantityLocation2: null,
+        newQuantityLocation2: null,
+        changeAmountLocation2: null,
+        transferDirection: null,
+      }),
+    ]);
     expect(db.select).toHaveBeenCalled();
+  });
+
+  it("should fall back to legacy Hagga/Deep Desert quantity columns", async () => {
+    const mockHistory = [
+      {
+        id: "2",
+        resourceId: "123",
+        previousQuantityHagga: 10,
+        newQuantityHagga: 20,
+        changeAmountHagga: 10,
+        previousQuantityDeepDesert: 5,
+        newQuantityDeepDesert: 5,
+        changeAmountDeepDesert: 0,
+        transferDirection: "to_hagga",
+      },
+    ];
+    (db.select as jest.Mock).mockReturnValue({
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue(mockHistory),
+    });
+
+    const request = new NextRequest(
+      "http://localhost/api/internal/resources/123/history",
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: "123" }),
+    });
+    const body = await response.json();
+
+    expect(body[0]).toEqual(
+      expect.objectContaining({
+        previousQuantityLocation1: 10,
+        newQuantityLocation1: 20,
+        changeAmountLocation1: 10,
+        previousQuantityLocation2: 5,
+        newQuantityLocation2: 5,
+        changeAmountLocation2: 0,
+        transferDirection: "transfer_to_location_1",
+      }),
+    );
   });
 
   it("should default to 7 days if days parameter is not provided", async () => {

--- a/tests/api/internal/resources/route.test.ts
+++ b/tests/api/internal/resources/route.test.ts
@@ -34,8 +34,78 @@ describe("GET /api/internal/resources", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body).toEqual(mockResources);
+    // GET augments each resource with location-agnostic quantity fields
+    // (falling back to 0 when the Hagga/Deep Desert columns are absent) and
+    // preserves the original category (null here -> null).
+    expect(body).toEqual([
+      {
+        id: "1",
+        name: "Resource 1",
+        category: null,
+        quantityLocation1: 0,
+        quantityLocation2: 0,
+      },
+      {
+        id: "2",
+        name: "Resource 2",
+        category: null,
+        quantityLocation1: 0,
+        quantityLocation2: 0,
+      },
+    ]);
     expect(db.select).toHaveBeenCalled();
+  });
+
+  it("should map legacy 'Blueprints' category to 'Gear Blueprints'", async () => {
+    const mockResources = [
+      {
+        id: "3",
+        name: "Old Blueprint",
+        category: "Blueprints",
+        quantityHagga: 5,
+        quantityDeepDesert: 2,
+      },
+    ];
+    (db.select as jest.Mock).mockReturnValue({
+      from: jest.fn().mockResolvedValue(mockResources),
+    });
+
+    const request = new NextRequest("http://localhost/api/internal/resources");
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body[0]).toEqual(
+      expect.objectContaining({
+        category: "Gear Blueprints",
+        quantityLocation1: 5,
+        quantityLocation2: 2,
+      }),
+    );
+  });
+
+  it("should prefer new location columns when present", async () => {
+    const mockResources = [
+      {
+        id: "4",
+        name: "With Loc",
+        category: "Raw",
+        quantityHagga: 5,
+        quantityDeepDesert: 2,
+        quantityLocation1: 100,
+        quantityLocation2: 50,
+      },
+    ];
+    (db.select as jest.Mock).mockReturnValue({
+      from: jest.fn().mockResolvedValue(mockResources),
+    });
+
+    const request = new NextRequest("http://localhost/api/internal/resources");
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(body[0].quantityLocation1).toBe(100);
+    expect(body[0].quantityLocation2).toBe(50);
   });
 
   it("should return a 500 error on failure", async () => {

--- a/tests/api/internal/user/activity/route.test.ts
+++ b/tests/api/internal/user/activity/route.test.ts
@@ -60,8 +60,10 @@ describe("GET /api/internal/user/activity", () => {
       {
         id: 1,
         resourceName: "Wood",
+        resourceCategory: "Raw",
         changeAmountHagga: 10,
         changeAmountDeepDesert: 5,
+        transferDirection: null,
       },
     ];
     mockLimit.mockResolvedValue(mockActivity);
@@ -74,7 +76,21 @@ describe("GET /api/internal/user/activity", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body).toEqual([{ ...mockActivity[0], changeAmount: 15 }]);
+    expect(body).toEqual([
+      expect.objectContaining({
+        id: 1,
+        resourceName: "Wood",
+        resourceCategory: "Raw",
+        changeAmount: 15,
+        previousQuantityLocation1: null,
+        newQuantityLocation1: null,
+        changeAmountLocation1: 10,
+        previousQuantityLocation2: null,
+        newQuantityLocation2: null,
+        changeAmountLocation2: 5,
+        transferDirection: null,
+      }),
+    ]);
     expect(db.db.where).toHaveBeenCalled();
   });
 
@@ -84,8 +100,10 @@ describe("GET /api/internal/user/activity", () => {
       {
         id: 2,
         resourceName: "Stone",
+        resourceCategory: "Blueprints",
         changeAmountHagga: -5,
         changeAmountDeepDesert: 0,
+        transferDirection: "to_deep_desert",
       },
     ];
     mockLimit.mockResolvedValue(mockActivity);
@@ -98,7 +116,17 @@ describe("GET /api/internal/user/activity", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body).toEqual([{ ...mockActivity[0], changeAmount: -5 }]);
+    expect(body).toEqual([
+      expect.objectContaining({
+        id: 2,
+        resourceName: "Stone",
+        // Legacy "Blueprints" category is translated to "Gear Blueprints"
+        resourceCategory: "Gear Blueprints",
+        changeAmount: -5,
+        // Legacy transferDirection is translated to the new value
+        transferDirection: "transfer_to_location_2",
+      }),
+    ]);
     expect(db.db.where).toHaveBeenCalled();
   });
 

--- a/tests/api/resources/[id]/transfer/route.test.ts
+++ b/tests/api/resources/[id]/transfer/route.test.ts
@@ -192,7 +192,9 @@ describe("PUT /api/resources/[id]/transfer", () => {
       expect.objectContaining({
         changeType: "transfer",
         transferAmount: 10,
-        transferDirection: "to_deep_desert",
+        // Dual-write: legacy strings are translated to the new
+        // location-agnostic values when written to history.
+        transferDirection: "transfer_to_location_2",
         updatedBy: expect.any(String),
         previousQuantityHagga: 50,
         newQuantityHagga: 40,
@@ -200,6 +202,66 @@ describe("PUT /api/resources/[id]/transfer", () => {
         previousQuantityDeepDesert: 10,
         newQuantityDeepDesert: 20,
         changeAmountDeepDesert: 10,
+        previousQuantityLocation1: 50,
+        newQuantityLocation1: 40,
+        changeAmountLocation1: -10,
+        previousQuantityLocation2: 10,
+        newQuantityLocation2: 20,
+        changeAmountLocation2: 10,
+      }),
+    );
+  });
+
+  it("should accept the new transfer_to_location_2 direction", async () => {
+    const resource = {
+      id: "test-id",
+      quantityHagga: 50,
+      quantityDeepDesert: 10,
+    };
+    const updatedResource = {
+      ...resource,
+      quantityHagga: 40,
+      quantityDeepDesert: 20,
+    };
+
+    let capturedTxMock: any;
+    mockDb.transaction.mockImplementation(async (callback) => {
+      const whereMock = jest
+        .fn()
+        .mockResolvedValueOnce([resource])
+        .mockResolvedValueOnce([updatedResource]);
+
+      const mockInsertValues = jest.fn().mockResolvedValue(undefined);
+
+      capturedTxMock = {
+        select: jest.fn(() => ({
+          from: jest.fn(() => ({ where: whereMock })),
+        })),
+        update: jest.fn(() => ({
+          set: jest.fn(() => ({
+            where: jest.fn().mockResolvedValue(undefined),
+          })),
+        })),
+        insert: jest.fn(() => ({
+          values: mockInsertValues,
+        })),
+        mockInsertValues,
+      };
+      return callback(capturedTxMock);
+    });
+
+    const request = createRequest({
+      transferAmount: 10,
+      transferDirection: "transfer_to_location_2",
+    });
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: "test-id" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(capturedTxMock.mockInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transferDirection: "transfer_to_location_2",
       }),
     );
   });

--- a/tests/api/resources/route.test.ts
+++ b/tests/api/resources/route.test.ts
@@ -94,6 +94,139 @@ describe("POST /api/resources", () => {
     expect(response.status).toBe(403);
     expect(body).toEqual({ error: "Admin access required" });
   });
+
+  it("dual-writes quantities to both legacy and new location columns", async () => {
+    const capturedInsertValues: any[] = [];
+    const mockDb = {
+      transaction: jest.fn().mockImplementation(async (callback) => {
+        const tx = {
+          insert: jest.fn().mockReturnThis(),
+          values: jest.fn(function (this: any, v: any) {
+            capturedInsertValues.push(v);
+            return this;
+          }),
+          returning: jest.fn().mockResolvedValue([
+            {
+              id: "new-id",
+              name: "Test",
+              category: "Raw",
+              quantityHagga: 10,
+              quantityDeepDesert: 20,
+              quantityLocation1: 10,
+              quantityLocation2: 20,
+            },
+          ]),
+        };
+        return callback(tx);
+      }),
+    };
+    jest.doMock("@/lib/db", () => ({
+      db: mockDb,
+      resources: {},
+      resourceHistory: {},
+    }));
+    jest.doMock("@/lib/discord-roles", () => ({
+      hasResourceAccess: () => true,
+      hasResourceAdminAccess: () => true,
+    }));
+
+    const request = new NextRequest("http://localhost/api/resources", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Test",
+        category: "Raw",
+        quantityHagga: 10,
+        quantityDeepDesert: 20,
+      }),
+    });
+
+    const { POST } = await import("@/app/api/resources/route");
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    // First call: resources insert; second call: resourceHistory insert
+    const resourceInsert = capturedInsertValues[0];
+    expect(resourceInsert).toEqual(
+      expect.objectContaining({
+        quantityHagga: 10,
+        quantityLocation1: 10,
+        quantityDeepDesert: 20,
+        quantityLocation2: 20,
+      }),
+    );
+    const historyInsert = capturedInsertValues[1];
+    expect(historyInsert).toEqual(
+      expect.objectContaining({
+        previousQuantityHagga: 0,
+        newQuantityHagga: 10,
+        changeAmountHagga: 10,
+        previousQuantityLocation1: 0,
+        newQuantityLocation1: 10,
+        changeAmountLocation1: 10,
+        previousQuantityDeepDesert: 0,
+        newQuantityDeepDesert: 20,
+        changeAmountDeepDesert: 20,
+        previousQuantityLocation2: 0,
+        newQuantityLocation2: 20,
+        changeAmountLocation2: 20,
+      }),
+    );
+  });
+
+  it("accepts location-agnostic quantityLocation1/2 in POST body", async () => {
+    const capturedInsertValues: any[] = [];
+    const mockDb = {
+      transaction: jest.fn().mockImplementation(async (callback) => {
+        const tx = {
+          insert: jest.fn().mockReturnThis(),
+          values: jest.fn(function (this: any, v: any) {
+            capturedInsertValues.push(v);
+            return this;
+          }),
+          returning: jest.fn().mockResolvedValue([
+            {
+              id: "new-id",
+              quantityHagga: 7,
+              quantityDeepDesert: 3,
+            },
+          ]),
+        };
+        return callback(tx);
+      }),
+    };
+    jest.doMock("@/lib/db", () => ({
+      db: mockDb,
+      resources: {},
+      resourceHistory: {},
+    }));
+    jest.doMock("@/lib/discord-roles", () => ({
+      hasResourceAccess: () => true,
+      hasResourceAdminAccess: () => true,
+    }));
+
+    const request = new NextRequest("http://localhost/api/resources", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Test",
+        category: "Raw",
+        quantityLocation1: 7,
+        quantityLocation2: 3,
+      }),
+    });
+
+    const { POST } = await import("@/app/api/resources/route");
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    expect(capturedInsertValues[0]).toEqual(
+      expect.objectContaining({
+        quantityHagga: 7,
+        quantityLocation1: 7,
+        quantityDeepDesert: 3,
+        quantityLocation2: 3,
+      }),
+    );
+  });
 });
 
 describe("PUT /api/resources", () => {

--- a/tests/lib/global-settings.test.ts
+++ b/tests/lib/global-settings.test.ts
@@ -1,0 +1,77 @@
+import {
+  DEFAULT_LOCATION_1_NAME,
+  DEFAULT_LOCATION_2_NAME,
+  LOCATION_1_NAME_KEY,
+  LOCATION_2_NAME_KEY,
+  getLocationNames,
+} from "@/lib/global-settings";
+
+describe("getLocationNames", () => {
+  const makeDb = (rows: { settingKey: string; settingValue: string | null }[]) => ({
+    select: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockResolvedValue(rows),
+  });
+
+  it("returns the configured names when both settings are present", async () => {
+    const db = makeDb([
+      { settingKey: LOCATION_1_NAME_KEY, settingValue: "Arrakeen" },
+      { settingKey: LOCATION_2_NAME_KEY, settingValue: "Sietch Tabr" },
+    ]);
+    const names = await getLocationNames(db);
+    expect(names).toEqual({
+      location1Name: "Arrakeen",
+      location2Name: "Sietch Tabr",
+    });
+  });
+
+  it("falls back to defaults when settings are missing", async () => {
+    const db = makeDb([]);
+    const names = await getLocationNames(db);
+    expect(names).toEqual({
+      location1Name: DEFAULT_LOCATION_1_NAME,
+      location2Name: DEFAULT_LOCATION_2_NAME,
+    });
+  });
+
+  it("falls back to defaults when values are null", async () => {
+    const db = makeDb([
+      { settingKey: LOCATION_1_NAME_KEY, settingValue: null },
+      { settingKey: LOCATION_2_NAME_KEY, settingValue: null },
+    ]);
+    const names = await getLocationNames(db);
+    expect(names).toEqual({
+      location1Name: DEFAULT_LOCATION_1_NAME,
+      location2Name: DEFAULT_LOCATION_2_NAME,
+    });
+  });
+
+  it("falls back to defaults when values are empty/whitespace strings", async () => {
+    const db = makeDb([
+      { settingKey: LOCATION_1_NAME_KEY, settingValue: "" },
+      { settingKey: LOCATION_2_NAME_KEY, settingValue: "   " },
+    ]);
+    const names = await getLocationNames(db);
+    expect(names).toEqual({
+      location1Name: DEFAULT_LOCATION_1_NAME,
+      location2Name: DEFAULT_LOCATION_2_NAME,
+    });
+  });
+
+  it("returns defaults on database error", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const db = {
+      select: jest.fn().mockReturnThis(),
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockRejectedValue(new Error("boom")),
+    };
+    const names = await getLocationNames(db);
+    expect(names).toEqual({
+      location1Name: DEFAULT_LOCATION_1_NAME,
+      location2Name: DEFAULT_LOCATION_2_NAME,
+    });
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/tests/lib/leaderboard.test.ts
+++ b/tests/lib/leaderboard.test.ts
@@ -102,6 +102,33 @@ describe("awardPoints", () => {
     expect(mockDb.insert).toHaveBeenCalled();
     expect(mockDb.values).toHaveBeenCalled();
   });
+
+  it("should not create a leaderboard entry for the legacy 'Blueprints' category", async () => {
+    const mockDb = {
+      insert: jest.fn().mockReturnThis(),
+      values: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const { awardPoints } = await import("@/lib/leaderboard");
+    // Legacy "Blueprints" maps to "Gear Blueprints" which is an ineligible
+    // category, so no leaderboard entry should be created.
+    const result = await awardPoints(
+      "test-user",
+      "test-resource",
+      "ADD",
+      1000,
+      {
+        name: "Old BP",
+        category: "Blueprints",
+        status: "at_target",
+        multiplier: 1,
+      },
+      mockDb,
+    );
+
+    expect(result.finalPoints).toBe(0);
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
 });
 
 describe("getLeaderboard", () => {

--- a/tests/lib/resource-mapping.test.ts
+++ b/tests/lib/resource-mapping.test.ts
@@ -1,0 +1,116 @@
+import {
+  mapCategoryForRead,
+  mapHistoryRowForRead,
+  mapResourceRowForRead,
+  mapTransferDirectionForRead,
+} from "@/lib/resource-mapping";
+
+describe("mapCategoryForRead", () => {
+  it("translates 'Blueprints' -> 'Gear Blueprints'", () => {
+    expect(mapCategoryForRead("Blueprints")).toBe("Gear Blueprints");
+  });
+
+  it("leaves other categories untouched", () => {
+    expect(mapCategoryForRead("Raw")).toBe("Raw");
+    expect(mapCategoryForRead("Gear")).toBe("Gear");
+  });
+
+  it("leaves null/undefined untouched", () => {
+    expect(mapCategoryForRead(null)).toBeNull();
+    expect(mapCategoryForRead(undefined)).toBeUndefined();
+  });
+});
+
+describe("mapTransferDirectionForRead", () => {
+  it("maps legacy directions to the new values", () => {
+    expect(mapTransferDirectionForRead("to_hagga")).toBe("transfer_to_location_1");
+    expect(mapTransferDirectionForRead("to_deep_desert")).toBe(
+      "transfer_to_location_2",
+    );
+  });
+
+  it("preserves already-migrated directions", () => {
+    expect(mapTransferDirectionForRead("transfer_to_location_1")).toBe(
+      "transfer_to_location_1",
+    );
+    expect(mapTransferDirectionForRead("transfer_to_location_2")).toBe(
+      "transfer_to_location_2",
+    );
+  });
+
+  it("leaves null/undefined untouched", () => {
+    expect(mapTransferDirectionForRead(null)).toBeNull();
+    expect(mapTransferDirectionForRead(undefined)).toBeUndefined();
+  });
+});
+
+describe("mapResourceRowForRead", () => {
+  it("falls back to Hagga/Deep Desert when location columns are null", () => {
+    const result = mapResourceRowForRead({
+      id: "1",
+      quantityHagga: 7,
+      quantityDeepDesert: 3,
+      quantityLocation1: null,
+      quantityLocation2: null,
+      category: "Raw",
+    });
+    expect(result.quantityLocation1).toBe(7);
+    expect(result.quantityLocation2).toBe(3);
+    expect(result.category).toBe("Raw");
+  });
+
+  it("prefers new location columns when present", () => {
+    const result = mapResourceRowForRead({
+      id: "1",
+      quantityHagga: 7,
+      quantityDeepDesert: 3,
+      quantityLocation1: 100,
+      quantityLocation2: 50,
+      category: "Blueprints",
+    });
+    expect(result.quantityLocation1).toBe(100);
+    expect(result.quantityLocation2).toBe(50);
+    expect(result.category).toBe("Gear Blueprints");
+  });
+
+  it("defaults to 0 when both legacy and new columns are missing", () => {
+    const result = mapResourceRowForRead({ id: "1", category: null });
+    expect(result.quantityLocation1).toBe(0);
+    expect(result.quantityLocation2).toBe(0);
+  });
+});
+
+describe("mapHistoryRowForRead", () => {
+  it("falls back to Hagga/Deep Desert quantity columns", () => {
+    const result = mapHistoryRowForRead({
+      previousQuantityHagga: 10,
+      newQuantityHagga: 20,
+      changeAmountHagga: 10,
+      previousQuantityDeepDesert: 5,
+      newQuantityDeepDesert: 5,
+      changeAmountDeepDesert: 0,
+      transferDirection: "to_hagga",
+    });
+    expect(result.previousQuantityLocation1).toBe(10);
+    expect(result.newQuantityLocation1).toBe(20);
+    expect(result.changeAmountLocation1).toBe(10);
+    expect(result.previousQuantityLocation2).toBe(5);
+    expect(result.newQuantityLocation2).toBe(5);
+    expect(result.changeAmountLocation2).toBe(0);
+    expect(result.transferDirection).toBe("transfer_to_location_1");
+  });
+
+  it("prefers new location columns when present", () => {
+    const result = mapHistoryRowForRead({
+      previousQuantityHagga: 10,
+      newQuantityHagga: 20,
+      changeAmountHagga: 10,
+      previousQuantityLocation1: 99,
+      newQuantityLocation1: 100,
+      changeAmountLocation1: 1,
+    });
+    expect(result.previousQuantityLocation1).toBe(99);
+    expect(result.newQuantityLocation1).toBe(100);
+    expect(result.changeAmountLocation1).toBe(1);
+  });
+});


### PR DESCRIPTION
…y, and leaderboard

Implements Phase 3 of the location-naming refactor:
- Add GET /api/global-settings and getLocationNames() utility to read inventory_location_{1,2}_name settings, defaulting to Hagga/Deep Desert.
- Dual-write quantityHagga/quantityDeepDesert alongside quantityLocation1/2 on resource create, update, bulk update, and transfer paths; history entries now also dual-write the six Location1/2 tracking columns.
- Dual-read resources and resource history: Location1/2 fields fall back to the legacy Hagga/Deep Desert columns; category "Blueprints" is surfaced as "Gear Blueprints"; transferDirection "to_hagga" / "to_deep_desert" are surfaced as "transfer_to_location_1" / "transfer_to_location_2".
- /api/resources/[id]/transfer accepts both the legacy and new direction strings and always persists the new values.
- Leaderboard writes (awardPoints) now persist the new "Gear Blueprints" category explicitly; internal leaderboard and user activity reads translate any remaining legacy "Blueprints" rows on the way out.
- Add unit tests for the new helpers, API routes, and dual-write behavior.