### PR TITLE
fix: gate migrate+backfill on TURSO_DATABASE_URL and align direction …

### DIFF
--- a/lib/changelog.json
+++ b/lib/changelog.json
@@ -37,7 +37,7 @@
         },
         {
           "type": "improvement",
-          "description": "Added idempotent historical data backfill script (scripts/backfill-inventory-locations.ts) that copies legacy Hagga/Deep Desert quantity and history values to the new Location 1/2 columns and translates transfer_direction values. Wired into the build pipeline after db:migrate and guarded by an 'inventory_data_backfilled' flag in global_settings so it runs exactly once across Vercel deployments."
+          "description": "Added idempotent historical data backfill script (scripts/backfill-inventory-locations.ts) that copies legacy Hagga/Deep Desert quantity and history values to the new Location 1/2 columns and translates transfer_direction values ('to_hagga'/'to_deep_desert' → 'transfer_to_location_1'/'transfer_to_location_2') to match the constants in lib/constants.ts. The three UPDATE statements and the flag write run in a single client.batch('write') transaction. Wired into the build pipeline alongside a new scripts/db-migrate-if-configured.ts wrapper that skips drizzle-kit migrate and the backfill when TURSO_DATABASE_URL is unset (CI/build check), while running them normally on Vercel. Guarded by an 'inventory_data_backfilled' flag in global_settings so it runs exactly once across deployments."
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "npm run db:generate-hashes && npm run db:migrate && tsx scripts/backfill-inventory-locations.ts && next build",
+    "build": "npm run db:generate-hashes && tsx scripts/db-migrate-if-configured.ts && tsx scripts/backfill-inventory-locations.ts && next build",
     "start": "next start",
     "lint": "eslint .",
     "test": "jest",

--- a/scripts/backfill-inventory-locations.ts
+++ b/scripts/backfill-inventory-locations.ts
@@ -32,53 +32,51 @@ async function runBackfill() {
 
     console.log("Starting historical data backfill for inventory locations...");
 
-    const resUpdate = await client.execute(`
-      UPDATE resources
-      SET
-        quantity_location_1 = quantity_hagga,
-        quantity_location_2 = quantity_deep_desert;
-    `);
-    console.log(`Resources backfilled: ${resUpdate.rowsAffected} rows affected.`);
-
-    const historyUpdate = await client.execute(`
-      UPDATE resource_history
-      SET
-        previous_quantity_location_1 = previous_quantity_hagga,
-        new_quantity_location_1 = new_quantity_hagga,
-        change_amount_location_1 = change_amount_hagga,
-        previous_quantity_location_2 = previous_quantity_deep_desert,
-        new_quantity_location_2 = new_quantity_deep_desert,
-        change_amount_location_2 = change_amount_deep_desert;
-    `);
-    console.log(`History backfilled: ${historyUpdate.rowsAffected} rows affected.`);
-
-    const directionUpdate = await client.execute(`
-      UPDATE resource_history
-      SET transfer_direction =
-        CASE
-          WHEN transfer_direction = 'to_hagga' THEN 'to_location_1'
-          WHEN transfer_direction = 'to_deep_desert' THEN 'to_location_2'
-          ELSE transfer_direction
-        END
-      WHERE transfer_direction IN ('to_hagga', 'to_deep_desert');
-    `);
-    console.log(`Transfer directions updated: ${directionUpdate.rowsAffected} rows affected.`);
-
     const timestamp = Date.now();
-    await client.execute(`
-      INSERT INTO global_settings (setting_key, setting_value, description, created_at, last_updated_at)
-      VALUES (
-        'inventory_data_backfilled',
-        'true',
-        'Tracks if legacy Hagga/Deep Desert data was migrated to Location 1/2',
-        ${timestamp},
-        ${timestamp}
-      )
-      ON CONFLICT(setting_key) DO UPDATE SET
-        setting_value = 'true',
-        last_updated_at = ${timestamp};
-    `);
 
+    const [resUpdate, historyUpdate, directionUpdate] = await client.batch(
+      [
+        `UPDATE resources
+          SET
+            quantity_location_1 = quantity_hagga,
+            quantity_location_2 = quantity_deep_desert;`,
+        `UPDATE resource_history
+          SET
+            previous_quantity_location_1 = previous_quantity_hagga,
+            new_quantity_location_1 = new_quantity_hagga,
+            change_amount_location_1 = change_amount_hagga,
+            previous_quantity_location_2 = previous_quantity_deep_desert,
+            new_quantity_location_2 = new_quantity_deep_desert,
+            change_amount_location_2 = change_amount_deep_desert;`,
+        `UPDATE resource_history
+          SET transfer_direction =
+            CASE
+              WHEN transfer_direction = 'to_hagga' THEN 'transfer_to_location_1'
+              WHEN transfer_direction = 'to_deep_desert' THEN 'transfer_to_location_2'
+              ELSE transfer_direction
+            END
+          WHERE transfer_direction IN ('to_hagga', 'to_deep_desert');`,
+        {
+          sql: `INSERT INTO global_settings (setting_key, setting_value, description, created_at, last_updated_at)
+            VALUES (
+              'inventory_data_backfilled',
+              'true',
+              'Tracks if legacy Hagga/Deep Desert data was migrated to Location 1/2',
+              ?,
+              ?
+            )
+            ON CONFLICT(setting_key) DO UPDATE SET
+              setting_value = 'true',
+              last_updated_at = ?;`,
+          args: [timestamp, timestamp, timestamp],
+        },
+      ],
+      "write",
+    );
+
+    console.log(`Resources backfilled: ${resUpdate.rowsAffected} rows affected.`);
+    console.log(`History backfilled: ${historyUpdate.rowsAffected} rows affected.`);
+    console.log(`Transfer directions updated: ${directionUpdate.rowsAffected} rows affected.`);
     console.log("Backfill complete and flagged in global_settings.");
 
   } catch (error) {

--- a/scripts/db-migrate-if-configured.ts
+++ b/scripts/db-migrate-if-configured.ts
@@ -1,0 +1,15 @@
+import { spawnSync } from "node:child_process";
+
+if (!process.env.TURSO_DATABASE_URL) {
+  console.warn(
+    "Skipping drizzle-kit migrate: TURSO_DATABASE_URL is not set (likely CI/build check).",
+  );
+  process.exit(0);
+}
+
+const result = spawnSync("npx", ["drizzle-kit", "migrate"], {
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
…strings

- Add scripts/db-migrate-if-configured.ts wrapper that skips drizzle-kit migrate when TURSO_DATABASE_URL is unset (GitHub CI / build check) and runs it normally on Vercel. Swap the build script to call the wrapper instead of db:migrate directly.
- Backfill script now uses client.batch(..., "write") so the three UPDATEs and the global_settings flag write commit atomically.
- Fix transfer_direction translation to emit the 'transfer_to_location_1' / 'transfer_to_location_2' values defined in lib/constants.ts and lib/resource-mapping.ts (previously wrote 'to_location_1' / 'to_location_2', which mapTransferDirectionForRead would not recognize).