### PR TITLE
Fix review findings: auth, validation, mapping, and scoring bugs

### DIFF
--- a/app/api/internal/leaderboard/route.ts
+++ b/app/api/internal/leaderboard/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getLeaderboard } from "@/lib/leaderboard";
-import { mapCategoryForRead } from "@/lib/resource-mapping";
 
 export const dynamic = "force-dynamic";
 
@@ -34,14 +33,8 @@ export async function GET(request: NextRequest) {
 
     const result = await getLeaderboard(timeFilter, effectiveLimit, offset);
 
-    const mappedRankings = result.rankings.map((entry: any) =>
-      entry && typeof entry === "object" && "resourceCategory" in entry
-        ? { ...entry, resourceCategory: mapCategoryForRead(entry.resourceCategory) }
-        : entry,
-    );
-
     return NextResponse.json({
-      leaderboard: mappedRankings,
+      leaderboard: result.rankings,
       timeFilter,
       total: result.total,
       page,

--- a/app/api/internal/resources/[id]/history/route.ts
+++ b/app/api/internal/resources/[id]/history/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
 import { db, resourceHistory } from "@/lib/db";
 import { eq, gte, desc, and } from "drizzle-orm";
+import { hasResourceAccess } from "@/lib/discord-roles";
 import { mapHistoryRowForRead } from "@/lib/resource-mapping";
 
 export const dynamic = "force-dynamic";
@@ -21,6 +24,11 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const session = await getServerSession(authOptions);
+  if (!session || !hasResourceAccess(session.user.roles)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const days = Math.max(1, Math.min(500, parseInt(searchParams.get("days") || "7", 10) || 7));

--- a/app/api/internal/resources/route.ts
+++ b/app/api/internal/resources/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
 import { db, resources } from "@/lib/db";
+import { hasResourceAccess } from "@/lib/discord-roles";
 import { mapResourceRowForRead } from "@/lib/resource-mapping";
 
 export const dynamic = "force-dynamic";
@@ -17,6 +20,11 @@ export const dynamic = "force-dynamic";
  * category is returned as "Gear Blueprints".
  */
 export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || !hasResourceAccess(session.user.roles)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const allResources = await db.select().from(resources);
 

--- a/app/api/internal/user/activity/route.ts
+++ b/app/api/internal/user/activity/route.ts
@@ -90,8 +90,9 @@ export async function GET(request: NextRequest) {
       .limit(limit);
 
     const processedActivity = activity.map((entry) => {
-      const totalChangeAmount =
-        (entry.changeAmountHagga || 0) + (entry.changeAmountDeepDesert || 0);
+      const loc1Amount = (entry.changeAmountLocation1 ?? entry.changeAmountHagga) ?? 0;
+      const loc2Amount = (entry.changeAmountLocation2 ?? entry.changeAmountDeepDesert) ?? 0;
+      const totalChangeAmount = loc1Amount + loc2Amount;
       return {
         ...entry,
         resourceCategory: mapCategoryForRead(entry.resourceCategory),

--- a/app/api/resources/[id]/route.ts
+++ b/app/api/resources/[id]/route.ts
@@ -151,6 +151,9 @@ export async function PUT(
             : quantity - previousQuantityDeepDesert;
         newQuantityDeepDesert =
           previousQuantityDeepDesert + changeAmountDeepDesert;
+        if (newQuantityDeepDesert < 0) {
+          throw new Error("ValidationError:NegativeQuantity");
+        }
       } else {
         // default to location 1 (legacy: hagga)
         changeAmountHagga =
@@ -158,6 +161,9 @@ export async function PUT(
             ? changeValue
             : quantity - previousQuantityHagga;
         newQuantityHagga = previousQuantityHagga + changeAmountHagga;
+        if (newQuantityHagga < 0) {
+          throw new Error("ValidationError:NegativeQuantity");
+        }
       }
 
       // Update the resource (dual-write to legacy + location-agnostic columns)
@@ -207,7 +213,7 @@ export async function PUT(
               : "REMOVE";
 
         const resourceStatus = calculateResourceStatus(
-          resource.quantityHagga + resource.quantityDeepDesert,
+          newQuantityHagga + newQuantityDeepDesert,
           resource.targetQuantity,
         );
 
@@ -253,6 +259,12 @@ export async function PUT(
       return NextResponse.json(
         { error: "Resource not found" },
         { status: 404 },
+      );
+    }
+    if (errorMessage === "ValidationError:NegativeQuantity") {
+      return NextResponse.json(
+        { error: "Relative update would result in a negative quantity" },
+        { status: 400 },
       );
     }
     console.error("Error updating resource:", error);

--- a/app/api/resources/bulk/confirm/route.ts
+++ b/app/api/resources/bulk/confirm/route.ts
@@ -45,6 +45,24 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid update data" }, { status: 400 });
   }
 
+  for (const item of updates) {
+    if (
+      !item ||
+      typeof item !== "object" ||
+      typeof item.id !== "string" ||
+      !item.id ||
+      !item.new ||
+      typeof item.new !== "object" ||
+      !Number.isFinite(item.new.quantityHagga) ||
+      !Number.isFinite(item.new.quantityDeepDesert)
+    ) {
+      return NextResponse.json(
+        { error: "Each update must have a valid id and numeric quantities" },
+        { status: 400 },
+      );
+    }
+  }
+
   try {
     await db.transaction(async (tx) => {
       const changedUpdates = updates.filter(

--- a/app/api/resources/route.ts
+++ b/app/api/resources/route.ts
@@ -7,7 +7,7 @@ import { hasResourceAccess, hasResourceAdminAccess } from "@/lib/discord-roles";
 import { nanoid } from "nanoid";
 import { awardPoints } from "@/lib/leaderboard";
 import { calculateResourceStatus } from "@/lib/resource-utils";
-import { mapCategoryForRead } from "@/lib/resource-mapping";
+import { mapCategoryForRead, mapResourceRowForRead } from "@/lib/resource-mapping";
 
 /**
  * GET /api/resources
@@ -107,8 +107,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const location1Qty = quantityLocation1 ?? quantityHagga ?? quantity ?? 0;
-    const location2Qty = quantityLocation2 ?? quantityDeepDesert ?? 0;
+    const rawLocation1 = quantityLocation1 ?? quantityHagga ?? quantity ?? 0;
+    const rawLocation2 = quantityLocation2 ?? quantityDeepDesert ?? 0;
+
+    const location1Qty = Number(rawLocation1);
+    const location2Qty = Number(rawLocation2);
+
+    if (
+      !Number.isInteger(location1Qty) || location1Qty < 0 ||
+      !Number.isInteger(location2Qty) || location2Qty < 0
+    ) {
+      return NextResponse.json(
+        { error: "Quantities must be non-negative integers" },
+        { status: 400 },
+      );
+    }
 
     const newResource = {
       id: nanoid(),
@@ -306,6 +319,10 @@ export async function PUT(request: NextRequest) {
             update.updateType === "relative"
               ? update.value
               : update.quantity - previousQuantityHagga;
+          const newQuantityHagga =
+            update.updateType === "relative"
+              ? previousQuantityHagga + update.value
+              : update.quantity;
 
           await db
             .update(resources)
@@ -355,7 +372,7 @@ export async function PUT(request: NextRequest) {
                 name: resource.name,
                 category: mapCategoryForRead(resource.category) || "Other",
                 status: calculateResourceStatus(
-                  resource.quantityHagga + resource.quantityDeepDesert,
+                  newQuantityHagga + resource.quantityDeepDesert,
                   resource.targetQuantity,
                 ),
                 multiplier: resource.multiplier || 1.0,
@@ -378,7 +395,7 @@ export async function PUT(request: NextRequest) {
 
       return NextResponse.json(
         {
-          resources: updatedResources,
+          resources: updatedResources.map(mapResourceRowForRead),
           totalPointsEarned,
           pointsBreakdown: pointsResults.filter((result) => result !== null),
         },

--- a/app/resources/[id]/page.tsx
+++ b/app/resources/[id]/page.tsx
@@ -1862,7 +1862,8 @@ export default function ResourceDetailPage() {
                             {entry.changeType === "transfer" ? (
                               <span>
                                 Transfer {entry.transferAmount}{" "}
-                                {entry.transferDirection === "to_deep_desert"
+                                {entry.transferDirection === "transfer_to_location_2" ||
+                                entry.transferDirection === "to_deep_desert"
                                   ? "to Deep Desert"
                                   : "to Hagga"}
                               </span>

--- a/lib/global-settings.ts
+++ b/lib/global-settings.ts
@@ -41,11 +41,11 @@ export async function getLocationNames(
 
     const location1Name =
       typeof rawLoc1 === "string" && rawLoc1.trim().length > 0
-        ? rawLoc1
+        ? rawLoc1.trim()
         : DEFAULT_LOCATION_1_NAME;
     const location2Name =
       typeof rawLoc2 === "string" && rawLoc2.trim().length > 0
-        ? rawLoc2
+        ? rawLoc2.trim()
         : DEFAULT_LOCATION_2_NAME;
 
     return { location1Name, location2Name };

--- a/lib/leaderboard.ts
+++ b/lib/leaderboard.ts
@@ -119,8 +119,7 @@ export async function awardPoints(
 ): Promise<PointsCalculation> {
   // Normalize legacy category strings before persisting — the leaderboard
   // always stores the new location/role-agnostic category names.
-  const normalizedCategory =
-    mapCategoryForRead(resourceData.category) ?? resourceData.category;
+  const normalizedCategory = mapCategoryForRead(resourceData.category);
 
   const calculation = calculatePoints(
     actionType,

--- a/lib/resource-mapping.ts
+++ b/lib/resource-mapping.ts
@@ -63,10 +63,17 @@ type ResourceRowShape = {
 export function mapResourceRowForRead<T extends ResourceRowShape>(
   row: T,
 ): T & { quantityLocation1: number; quantityLocation2: number } {
+  // The schema adds `quantity_location_1/2` with DEFAULT 0 NOT NULL, so a value of
+  // 0 may mean "not yet backfilled" rather than genuinely zero. Prefer the legacy
+  // column when it is non-zero and the new column is still at the default of 0.
   const quantityLocation1 =
-    row.quantityLocation1 ?? row.quantityHagga ?? 0;
+    row.quantityLocation1 === 0 && row.quantityHagga != null && row.quantityHagga !== 0
+      ? row.quantityHagga
+      : (row.quantityLocation1 ?? row.quantityHagga ?? 0);
   const quantityLocation2 =
-    row.quantityLocation2 ?? row.quantityDeepDesert ?? 0;
+    row.quantityLocation2 === 0 && row.quantityDeepDesert != null && row.quantityDeepDesert !== 0
+      ? row.quantityDeepDesert
+      : (row.quantityLocation2 ?? row.quantityDeepDesert ?? 0);
   const category = mapCategoryForRead(row.category ?? null);
 
   return {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "npm run db:generate-hashes && tsx scripts/db-migrate-if-configured.ts && tsx scripts/backfill-inventory-locations.ts && next build",
+    "build": "npm run db:generate-hashes && next build",
+    "release:migrate": "tsx scripts/db-migrate-if-configured.ts",
+    "release:backfill": "tsx scripts/backfill-inventory-locations.ts",
     "start": "next start",
     "lint": "eslint .",
     "test": "jest",

--- a/scripts/backfill-inventory-locations.ts
+++ b/scripts/backfill-inventory-locations.ts
@@ -26,8 +26,12 @@ async function runBackfill() {
     try {
       await client.execute(`SELECT quantity_location_1 FROM resources LIMIT 1`);
     } catch (e) {
-      console.warn("Target columns do not exist. Schema migration likely hasn't run. Skipping backfill.");
-      return;
+      const msg = e instanceof Error ? e.message : String(e);
+      if (/column.*does not exist|no such column/i.test(msg)) {
+        console.warn("Target columns do not exist. Schema migration likely hasn't run. Skipping backfill.");
+        return;
+      }
+      throw e;
     }
 
     console.log("Starting historical data backfill for inventory locations...");
@@ -80,7 +84,8 @@ async function runBackfill() {
     console.log("Backfill complete and flagged in global_settings.");
 
   } catch (error) {
-    console.error("Critical error during backfill:", error);
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error("Critical error during backfill:", msg);
     process.exit(1);
   } finally {
     client.close();


### PR DESCRIPTION
- Remove no-op mappedRankings block in internal leaderboard route (getLeaderboard returns {userId,totalPoints,totalActions}, no resourceCategory)
- Add session + hasResourceAccess guard to internal resources GET and internal resource history GET (defense-in-depth for internal routes)
- Reject relative quantity updates that would produce a negative quantity in PUT /api/resources/[id]
- Calculate resourceStatus from post-change totals (not pre-change) when awarding points in both single-resource and bulk update paths
- Add non-negative integer validation for quantities in POST /api/resources
- Apply mapResourceRowForRead to the bulk PUT response so location-agnostic fields are always populated for callers
- Import mapResourceRowForRead in resources/route.ts (was missing)
- Fix transfer direction labels in history UI: handle transfer_to_location_2 and transfer_to_location_1 alongside the legacy to_deep_desert/to_hagga
- Fix global-settings.ts to return rawLoc.trim() (was returning untrimmed value despite validating the trimmed length)
- Fix mapResourceRowForRead to prefer the legacy Hagga/DeepDesert column when quantityLocation1/2 is still at its DEFAULT 0 (pre-backfill rows)
- Remove db:migrate and backfill from the build script; add release:migrate and release:backfill scripts so they run only on explicit deploy steps
- Narrow backfill column-missing catch to only swallow the expected "no such column" error; re-throw others; normalize error message in the outer catch
- Fix totalChangeAmount in user activity to use changeAmountLocation1/2 with Hagga/DeepDesert fallback instead of ignoring location-only rows
- Add per-item validation in bulk/confirm route before writing to DB
- Remove dead-code ?? fallback in leaderboard.ts awardPoints (mapCategoryForRead never returns null/undefined)
- Note: backfill direction values were already correct (transfer_to_location_1/2); that review finding was a false positive and no change was made there

https://claude.ai/code/session_017H2fDCjRLFJaz8hKf3fosM