### PR TITLE
Use dynamic location names in CSV export/import

### DIFF
--- a/app/api/resources/bulk/route.ts
+++ b/app/api/resources/bulk/route.ts
@@ -9,14 +9,7 @@ import {
   UPDATE_THRESHOLD_NON_PRIORITY_MS,
   UPDATE_THRESHOLD_PRIORITY_MS,
 } from "@/lib/constants";
-
-interface CsvRow {
-  id: string;
-  name: string;
-  quantityHagga: string;
-  quantityDeepDesert: string;
-  targetQuantity: string;
-}
+import { getLocationNames } from "@/lib/global-settings";
 
 // Formula injection prevention: prefix values that would be interpreted as
 // spreadsheet formulas (=, +, -, @, tab, carriage-return) with a single quote.
@@ -191,11 +184,13 @@ export async function GET(request: NextRequest) {
     .where(and(...whereConditions));
   const filteredResources = await query;
 
+  const { location1Name, location2Name } = await getLocationNames();
+
   const dataForCsv = filteredResources.map((r) => ({
     id: sanitizeCsvField(r.id),
     name: sanitizeCsvField(r.name),
-    quantityHagga: r.quantityHagga,
-    quantityDeepDesert: r.quantityDeepDesert,
+    [location1Name]: r.quantityHagga,
+    [location2Name]: r.quantityDeepDesert,
     targetQuantity: r.targetQuantity,
   }));
 
@@ -255,16 +250,32 @@ export async function POST(request: NextRequest) {
   }
 
   const csvData = await file.text();
-  const parsed = Papa.parse<CsvRow>(csvData, {
+  const parsed = Papa.parse<Record<string, string>>(csvData, {
     header: true,
     skipEmptyLines: true,
   });
 
-  const requiredColumns = ["id", "name", "quantityHagga", "quantityDeepDesert"];
+  const { location1Name, location2Name } = await getLocationNames();
   const presentColumns = parsed.meta.fields ?? [];
-  const missingColumns = requiredColumns.filter(
-    (col) => !presentColumns.includes(col),
-  );
+
+  // Accept either the configured location names or the legacy column names
+  const loc1Key = presentColumns.includes(location1Name)
+    ? location1Name
+    : presentColumns.includes("quantityHagga")
+      ? "quantityHagga"
+      : null;
+  const loc2Key = presentColumns.includes(location2Name)
+    ? location2Name
+    : presentColumns.includes("quantityDeepDesert")
+      ? "quantityDeepDesert"
+      : null;
+
+  const missingColumns = [
+    ...(!presentColumns.includes("id") ? ["id"] : []),
+    ...(!presentColumns.includes("name") ? ["name"] : []),
+    ...(!loc1Key ? [location1Name] : []),
+    ...(!loc2Key ? [location2Name] : []),
+  ];
   if (missingColumns.length > 0) {
     return NextResponse.json(
       {
@@ -301,20 +312,17 @@ export async function POST(request: NextRequest) {
     const newValues: any = {};
     const validationErrors: any = {};
 
-    const validateAndSet = (
-      value: any,
-      fieldName: "quantityHagga" | "quantityDeepDesert",
-    ) => {
+    const validateAndSet = (value: unknown, internalField: "quantityHagga" | "quantityDeepDesert") => {
       const num = Number(value);
       if (isNaN(num) || num < 0 || !Number.isInteger(num)) {
-        validationErrors[fieldName] = "Must be a positive integer";
+        validationErrors[internalField] = "Must be a positive integer";
       } else {
-        newValues[fieldName] = num;
+        newValues[internalField] = num;
       }
     };
 
-    validateAndSet(row.quantityHagga, "quantityHagga");
-    validateAndSet(row.quantityDeepDesert, "quantityDeepDesert");
+    validateAndSet(desanitizeCsvField(row[loc1Key!]), "quantityHagga");
+    validateAndSet(desanitizeCsvField(row[loc2Key!]), "quantityDeepDesert");
 
     // Validate targetQuantity
     const newTargetRaw = row.targetQuantity;
@@ -343,8 +351,8 @@ export async function POST(request: NextRequest) {
           targetQuantity: current.targetQuantity,
         },
         new: {
-          quantityHagga: row.quantityHagga,
-          quantityDeepDesert: row.quantityDeepDesert,
+          quantityHagga: row[loc1Key!],
+          quantityDeepDesert: row[loc2Key!],
           targetQuantity: row.targetQuantity,
         },
       };

--- a/app/components/BulkActions.tsx
+++ b/app/components/BulkActions.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSession } from "next-auth/react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { ImportModal } from "./ImportModal";
 import { ExportConfirmationModal } from "./ExportConfirmationModal";
 import { HardDriveDownload, FileInput } from "lucide-react";
@@ -22,6 +22,18 @@ export function BulkActions({
   const { data: session } = useSession();
   const [isImportModalOpen, setisImportModalOpen] = useState(false);
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
+  const [location1Name, setLocation1Name] = useState("Hagga");
+  const [location2Name, setLocation2Name] = useState("Deep Desert");
+
+  useEffect(() => {
+    fetch("/api/global-settings")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.location1Name) setLocation1Name(data.location1Name);
+        if (data.location2Name) setLocation2Name(data.location2Name);
+      })
+      .catch(() => {});
+  }, []);
 
   if (!session?.user?.permissions?.hasTargetEditAccess) {
     return null;
@@ -74,6 +86,8 @@ export function BulkActions({
       <ImportModal
         isOpen={isImportModalOpen}
         onClose={() => setisImportModalOpen(false)}
+        location1Name={location1Name}
+        location2Name={location2Name}
       />
       <ExportConfirmationModal
         isOpen={isExportModalOpen}

--- a/app/components/ImportModal.tsx
+++ b/app/components/ImportModal.tsx
@@ -33,9 +33,13 @@ interface DiffItem {
 export function ImportModal({
   isOpen,
   onClose,
+  location1Name = "Hagga",
+  location2Name = "Deep Desert",
 }: {
   isOpen: boolean;
   onClose: () => void;
+  location1Name?: string;
+  location2Name?: string;
 }) {
   const router = useRouter();
   const [file, setFile] = useState<File | null>(null);
@@ -129,6 +133,12 @@ export function ImportModal({
 
   const hasInvalidEntries = diff?.some((d) => d.status === "invalid");
 
+  const displayField = (field: string) => {
+    if (field === "quantityHagga") return location1Name;
+    if (field === "quantityDeepDesert") return location2Name;
+    return field;
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-background-overlay">
       <div className="mx-4 w-full max-w-4xl rounded-lg border border-border-primary bg-background-panel p-6">
@@ -148,8 +158,8 @@ export function ImportModal({
           <div>
             <label htmlFor="csv-upload" className="mb-4 text-text-secondary">
               Upload a CSV file to update resource quantities and targets. The
-              CSV must contain &apos;id&apos;, &apos;quantityHagga&apos;,
-              &apos;quantityDeepDesert&apos;, and &apos;targetQuantity&apos;
+              CSV must contain &apos;id&apos;, &apos;{location1Name}&apos;,
+              &apos;{location2Name}&apos;, and &apos;targetQuantity&apos;
               columns.
             </label>
             <input
@@ -229,7 +239,7 @@ export function ImportModal({
                           {item.name}
                         </td>
                         <td className="px-4 py-2 text-text-secondary">
-                          {item.field}
+                          {displayField(item.field!)}
                         </td>
                         <td className="px-4 py-2 text-text-secondary">
                           {item.old?.[item.field!] ?? "N/A"}


### PR DESCRIPTION
The exported CSV now uses the admin-configured location names (e.g. "Hagga", "Deep Desert", or any custom name) as column headers instead of the internal field names quantityHagga / quantityDeepDesert.

The import parser accepts both the configured names and the legacy internal names, so existing CSV files continue to work. When validation errors or diffs are shown in the modal, the field labels are mapped to the configured location names so users see the same names they're familiar with.

BulkActions fetches location names from /api/global-settings on mount and passes them to ImportModal. Both components default to "Hagga" / "Deep Desert" if the fetch fails or the settings are unconfigured.

https://claude.ai/code/session_017H2fDCjRLFJaz8hKf3fosM