### PR TITLE
Fix five review findings in bulk confirm, bulk validate, and resource…

### DIFF
--- a/app/api/resources/bulk/confirm/route.ts
+++ b/app/api/resources/bulk/confirm/route.ts
@@ -52,9 +52,20 @@ export async function POST(request: NextRequest) {
       typeof item.id !== "string" ||
       !item.id ||
       !item.new ||
-      typeof item.new !== "object" ||
-      !Number.isFinite(item.new.quantityHagga) ||
-      !Number.isFinite(item.new.quantityDeepDesert)
+      typeof item.new !== "object"
+    ) {
+      return NextResponse.json(
+        { error: "Each update must have a valid id and numeric quantities" },
+        { status: 400 },
+      );
+    }
+    const qtyHagga = Number(item.new.quantityHagga);
+    const qtyDeepDesert = Number(item.new.quantityDeepDesert);
+    if (
+      !Number.isInteger(qtyHagga) ||
+      qtyHagga < 0 ||
+      !Number.isInteger(qtyDeepDesert) ||
+      qtyDeepDesert < 0
     ) {
       return NextResponse.json(
         { error: "Each update must have a valid id and numeric quantities" },
@@ -100,38 +111,38 @@ export async function POST(request: NextRequest) {
           continue;
         }
 
+        const newQtyHagga = Number(update.new.quantityHagga);
+        const newQtyDeepDesert = Number(update.new.quantityDeepDesert);
+        const changeAmountHagga = newQtyHagga - current.quantityHagga;
+        const changeAmountDeepDesert = newQtyDeepDesert - current.quantityDeepDesert;
+
         await tx
           .update(resources)
           .set({
-            quantityHagga: update.new.quantityHagga,
-            quantityDeepDesert: update.new.quantityDeepDesert,
-            quantityLocation1: update.new.quantityHagga,
-            quantityLocation2: update.new.quantityDeepDesert,
+            quantityHagga: newQtyHagga,
+            quantityDeepDesert: newQtyDeepDesert,
+            quantityLocation1: newQtyHagga,
+            quantityLocation2: newQtyDeepDesert,
             targetQuantity: update.new.targetQuantity,
             lastUpdatedBy: userId,
             updatedAt: new Date(),
           })
           .where(eq(resources.id, update.id));
 
-        const changeAmountHagga =
-          update.new.quantityHagga - current.quantityHagga;
-        const changeAmountDeepDesert =
-          update.new.quantityDeepDesert - current.quantityDeepDesert;
-
         await tx.insert(resourceHistory).values({
           id: nanoid(),
           resourceId: update.id,
           previousQuantityHagga: current.quantityHagga,
-          newQuantityHagga: update.new.quantityHagga,
+          newQuantityHagga: newQtyHagga,
           changeAmountHagga,
           previousQuantityDeepDesert: current.quantityDeepDesert,
-          newQuantityDeepDesert: update.new.quantityDeepDesert,
+          newQuantityDeepDesert: newQtyDeepDesert,
           changeAmountDeepDesert,
           previousQuantityLocation1: current.quantityHagga,
-          newQuantityLocation1: update.new.quantityHagga,
+          newQuantityLocation1: newQtyHagga,
           changeAmountLocation1: changeAmountHagga,
           previousQuantityLocation2: current.quantityDeepDesert,
-          newQuantityLocation2: update.new.quantityDeepDesert,
+          newQuantityLocation2: newQtyDeepDesert,
           changeAmountLocation2: changeAmountDeepDesert,
           changeType: "absolute",
           updatedBy: userId,

--- a/app/api/resources/bulk/route.ts
+++ b/app/api/resources/bulk/route.ts
@@ -186,7 +186,13 @@ export async function GET(request: NextRequest) {
 
   const { location1Name, location2Name } = await getLocationNames();
 
-  const EXPORT_RESERVED = new Set(["id", "name", "targetQuantity"]);
+  const EXPORT_RESERVED = new Set([
+    "id",
+    "name",
+    "targetQuantity",
+    "quantityHagga",
+    "quantityDeepDesert",
+  ]);
   if (
     EXPORT_RESERVED.has(location1Name) ||
     EXPORT_RESERVED.has(location2Name) ||
@@ -388,9 +394,9 @@ export async function POST(request: NextRequest) {
           targetQuantity: current.targetQuantity,
         },
         new: {
-          quantityHagga: row[loc1Key!],
-          quantityDeepDesert: row[loc2Key!],
-          targetQuantity: row.targetQuantity,
+          quantityHagga: desanitizeCsvField(row[loc1Key!]),
+          quantityDeepDesert: desanitizeCsvField(row[loc2Key!]),
+          targetQuantity: desanitizeCsvField(row.targetQuantity),
         },
       };
     }

--- a/app/api/resources/route.ts
+++ b/app/api/resources/route.ts
@@ -345,6 +345,11 @@ export async function PUT(request: NextRequest) {
             update.updateType === "relative"
               ? previousQuantityHagga + update.value
               : update.quantity;
+          if (newQuantityHagga < 0) {
+            throw new Error(
+              `Relative update would result in a negative quantity for resource ${update.id}`,
+            );
+          }
           const changeAmountHagga = newQuantityHagga - previousQuantityHagga;
 
           await db


### PR DESCRIPTION
… PUT

bulk/confirm/route.ts:
- Replace Number.isFinite checks with Number() + isInteger + >= 0 so string quantities from the CSV/modal path are accepted and validated correctly
- Introduce newQtyHagga/newQtyDeepDesert locals so the DB write, history insert, and change-amount arithmetic all use the explicit number conversion

bulk/route.ts (GET export):
- Add quantityHagga and quantityDeepDesert to EXPORT_RESERVED so a location name that matches the legacy import column names is rejected at export time, ensuring every exported CSV can be round-tripped back through import

bulk/route.ts (POST import):
- Apply desanitizeCsvField() to the raw CSV values in the invalid row's new object so leading formula-injection quotes are stripped before the values reach the UI or a subsequent confirm request

resources/route.ts (PUT bulk):
- After computing newQuantityHagga for a relative update, throw if the result is negative to prevent invalid inventory states

https://claude.ai/code/session_01LxD7u4cv5m7mhvG2N2nE9H