### PR TITLE
Validate targetQuantity and batch history inserts in bulk confirm

### DIFF
--- a/app/api/resources/bulk/confirm/route.ts
+++ b/app/api/resources/bulk/confirm/route.ts
@@ -72,6 +72,16 @@ export async function POST(request: NextRequest) {
         { status: 400 },
       );
     }
+    const tgt = item.new.targetQuantity;
+    if (tgt !== null && tgt !== undefined) {
+      const targetNum = Number(tgt);
+      if (!Number.isInteger(targetNum) || targetNum < 0) {
+        return NextResponse.json(
+          { error: "Each update must have a valid id and numeric quantities" },
+          { status: 400 },
+        );
+      }
+    }
   }
 
   try {
@@ -105,6 +115,9 @@ export async function POST(request: NextRequest) {
         currentResources.map((r) => [r.id, r]),
       );
 
+      const now = new Date();
+      const historyEntries: (typeof resourceHistory.$inferInsert)[] = [];
+
       for (const update of uniqueChangedUpdates) {
         const current = currentResourcesMap.get(update.id);
         if (!current) {
@@ -113,8 +126,12 @@ export async function POST(request: NextRequest) {
 
         const newQtyHagga = Number(update.new.quantityHagga);
         const newQtyDeepDesert = Number(update.new.quantityDeepDesert);
+        const tgt = update.new.targetQuantity;
+        const newTargetQty =
+          tgt === null || tgt === undefined ? null : Number(tgt);
         const changeAmountHagga = newQtyHagga - current.quantityHagga;
-        const changeAmountDeepDesert = newQtyDeepDesert - current.quantityDeepDesert;
+        const changeAmountDeepDesert =
+          newQtyDeepDesert - current.quantityDeepDesert;
 
         await tx
           .update(resources)
@@ -123,13 +140,13 @@ export async function POST(request: NextRequest) {
             quantityDeepDesert: newQtyDeepDesert,
             quantityLocation1: newQtyHagga,
             quantityLocation2: newQtyDeepDesert,
-            targetQuantity: update.new.targetQuantity,
+            targetQuantity: newTargetQty,
             lastUpdatedBy: userId,
-            updatedAt: new Date(),
+            updatedAt: now,
           })
           .where(eq(resources.id, update.id));
 
-        await tx.insert(resourceHistory).values({
+        historyEntries.push({
           id: nanoid(),
           resourceId: update.id,
           previousQuantityHagga: current.quantityHagga,
@@ -144,11 +161,15 @@ export async function POST(request: NextRequest) {
           previousQuantityLocation2: current.quantityDeepDesert,
           newQuantityLocation2: newQtyDeepDesert,
           changeAmountLocation2: changeAmountDeepDesert,
-          changeType: "absolute",
+          changeType: "absolute" as const,
           updatedBy: userId,
           reason: "Bulk CSV import",
-          createdAt: new Date(),
+          createdAt: now,
         });
+      }
+
+      if (historyEntries.length > 0) {
+        await tx.insert(resourceHistory).values(historyEntries);
       }
     });
 

--- a/tests/api/resources/bulk/confirm/route.test.ts
+++ b/tests/api/resources/bulk/confirm/route.test.ts
@@ -133,18 +133,20 @@ describe("POST /api/resources/bulk/confirm", () => {
 
     expect(capturedTx.insert).toHaveBeenCalledWith(resourceHistory);
     expect(capturedTx.mockInsertValues).toHaveBeenCalledWith(
-      expect.objectContaining({
-        changeType: "absolute",
-        reason: "Bulk CSV import",
-        resourceId: "r1",
-        previousQuantityHagga: 10,
-        newQuantityHagga: 25,
-        changeAmountHagga: 15,
-        previousQuantityDeepDesert: 5,
-        newQuantityDeepDesert: 8,
-        changeAmountDeepDesert: 3,
-        updatedBy: expect.any(String),
-      }),
+      expect.arrayContaining([
+        expect.objectContaining({
+          changeType: "absolute",
+          reason: "Bulk CSV import",
+          resourceId: "r1",
+          previousQuantityHagga: 10,
+          newQuantityHagga: 25,
+          changeAmountHagga: 15,
+          previousQuantityDeepDesert: 5,
+          newQuantityDeepDesert: 8,
+          changeAmountDeepDesert: 3,
+          updatedBy: expect.any(String),
+        }),
+      ]),
     );
   });
 
@@ -194,10 +196,12 @@ describe("POST /api/resources/bulk/confirm", () => {
     // De-duplication: insert called exactly once for r1 (last entry wins)
     expect(capturedTx.mockInsertValues).toHaveBeenCalledTimes(1);
     expect(capturedTx.mockInsertValues).toHaveBeenCalledWith(
-      expect.objectContaining({
-        newQuantityHagga: 99,
-        newQuantityDeepDesert: 99,
-      }),
+      expect.arrayContaining([
+        expect.objectContaining({
+          newQuantityHagga: 99,
+          newQuantityDeepDesert: 99,
+        }),
+      ]),
     );
   });
 


### PR DESCRIPTION
bulk/confirm/route.ts:
- Validate targetQuantity in the pre-flight loop: must be null/undefined or a non-negative integer, preventing invalid values reaching the DB
- Normalize targetQuantity through Number() before the DB write
- Define a single `now` timestamp before the loop so all updatedAt/createdAt fields are logically grouped with the same value
- Collect resourceHistory rows in an array and perform one batch insert after the loop instead of one INSERT per row, reducing round-trips to O(1)

route.test.ts: update the two history-insert assertions to match the new
  batch form (values receives an array, not a single object)

https://claude.ai/code/session_01LxD7u4cv5m7mhvG2N2nE9H