### PR TITLE
fix: address review feedback on location names context and related files

### DIFF
--- a/app/api/global-settings/route.ts
+++ b/app/api/global-settings/route.ts
@@ -112,7 +112,10 @@ export async function PUT(request: NextRequest) {
 
     return NextResponse.json({ location1Name: trimmed1, location2Name: trimmed2 });
   } catch (error) {
-    console.error("Error updating global settings:", error);
+    console.error(
+      "Error updating global settings:",
+      error instanceof Error ? error.message : String(error),
+    );
     return NextResponse.json(
       { error: "Failed to update global settings" },
       { status: 500 },

--- a/app/components/TransferModal.tsx
+++ b/app/components/TransferModal.tsx
@@ -71,8 +71,9 @@ export function TransferModal({
     try {
       await onTransfer(resource.id, amount, direction);
       onClose();
-    } catch (err: any) {
-      setError(err.message || "An error occurred.");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setError(message || "An error occurred.");
     }
   };
 

--- a/app/context/LocationNamesContext.tsx
+++ b/app/context/LocationNamesContext.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
 
-interface LocationNames {
+interface LocationNamesContextValue {
   location1Name: string;
   location2Name: string;
+  refreshLocationNames: () => Promise<void>;
 }
 
-export const LocationNamesContext = createContext<LocationNames>({
-  location1Name: "Hagga",
-  location2Name: "Deep Desert",
+const DEFAULT_NAMES = { location1Name: "Hagga", location2Name: "Deep Desert" };
+
+export const LocationNamesContext = createContext<LocationNamesContextValue>({
+  ...DEFAULT_NAMES,
+  refreshLocationNames: async () => {},
 });
 
 export function LocationNamesProvider({
@@ -17,38 +20,38 @@ export function LocationNamesProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [names, setNames] = useState<LocationNames>({
-    location1Name: "Hagga",
-    location2Name: "Deep Desert",
-  });
+  const [names, setNames] = useState(DEFAULT_NAMES);
+
+  const fetchNames = useCallback(async (signal?: AbortSignal) => {
+    const r = await fetch("/api/global-settings", signal ? { signal } : {});
+    if (!r.ok) return;
+    const data = await r.json();
+    if (data?.location1Name && data?.location2Name) {
+      setNames({ location1Name: data.location1Name, location2Name: data.location2Name });
+    }
+  }, []);
 
   useEffect(() => {
     const controller = new AbortController();
-    fetch("/api/global-settings", { signal: controller.signal })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (data?.location1Name && data?.location2Name) {
-          setNames({
-            location1Name: data.location1Name,
-            location2Name: data.location2Name,
-          });
-        }
-      })
-      .catch((err) => {
-        if (err.name !== "AbortError") {
-          // fall back to defaults silently
-        }
-      });
+    fetchNames(controller.signal).catch((err) => {
+      if (err.name !== "AbortError") {
+        // fall back to defaults silently
+      }
+    });
     return () => controller.abort();
-  }, []);
+  }, [fetchNames]);
+
+  const refreshLocationNames = useCallback(async () => {
+    await fetchNames();
+  }, [fetchNames]);
 
   return (
-    <LocationNamesContext.Provider value={names}>
+    <LocationNamesContext.Provider value={{ ...names, refreshLocationNames }}>
       {children}
     </LocationNamesContext.Provider>
   );
 }
 
-export function useLocationNames(): LocationNames {
+export function useLocationNames(): LocationNamesContextValue {
   return useContext(LocationNamesContext);
 }

--- a/app/dashboard/activity/page.tsx
+++ b/app/dashboard/activity/page.tsx
@@ -49,7 +49,7 @@ interface ActivityEntry {
   newQuantityDeepDesert: number;
   changeAmountDeepDesert: number;
   transferAmount?: number;
-  transferDirection?: "to_deep_desert" | "to_hagga";
+  transferDirection?: "to_deep_desert" | "to_hagga" | "transfer_to_location_2" | "transfer_to_location_1";
   changeAmount: number; // This is the total change amount, added in the API
   changeType: "absolute" | "relative" | "transfer";
   reason?: string;
@@ -272,7 +272,8 @@ export default function ActivityLogPage() {
                             {activity.changeType === "transfer" ? (
                               <span>
                                 Transfer {activity.transferAmount}{" "}
-                                {activity.transferDirection === "to_deep_desert"
+                                {activity.transferDirection === "to_deep_desert" ||
+                                activity.transferDirection === "transfer_to_location_2"
                                   ? `to ${location2Name}`
                                   : `to ${location1Name}`}
                               </span>

--- a/app/dashboard/settings/SettingsForm.tsx
+++ b/app/dashboard/settings/SettingsForm.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useLocationNames } from "@/app/context/LocationNamesContext";
 
 export function SettingsForm() {
-  const [location1Name, setLocation1Name] = useState("");
-  const [location2Name, setLocation2Name] = useState("");
+  const { refreshLocationNames } = useLocationNames();
+  const [location1Name, setLocation1Name] = useState("Hagga");
+  const [location2Name, setLocation2Name] = useState("Deep Desert");
   const [loading, setLoading] = useState(true);
+  const [loadWarning, setLoadWarning] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
@@ -14,13 +17,18 @@ export function SettingsForm() {
     fetch("/api/global-settings")
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
-        if (data) {
-          setLocation1Name(data.location1Name || "Hagga");
-          setLocation2Name(data.location2Name || "Deep Desert");
+        if (data?.location1Name && data?.location2Name) {
+          setLocation1Name(data.location1Name);
+          setLocation2Name(data.location2Name);
+        } else {
+          setLoadWarning(true);
         }
         setLoading(false);
       })
-      .catch(() => setLoading(false));
+      .catch(() => {
+        setLoadWarning(true);
+        setLoading(false);
+      });
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -40,6 +48,7 @@ export function SettingsForm() {
         setError(data.error || "Failed to save settings");
       } else {
         setSuccess(true);
+        await refreshLocationNames();
       }
     } catch {
       setError("Network error, please try again");
@@ -67,6 +76,12 @@ export function SettingsForm() {
       <p className="mb-6 text-sm text-text-tertiary">
         Customize the display names for the two inventory locations shown throughout the app.
       </p>
+
+      {loadWarning && (
+        <div className="mb-4 rounded-md bg-background-warning p-3 text-sm text-text-warning">
+          Could not load current settings — showing defaults. You can still save new values.
+        </div>
+      )}
 
       <div className="space-y-4">
         <div>
@@ -116,7 +131,7 @@ export function SettingsForm() {
 
       {success && (
         <div className="mt-4 rounded-md bg-background-success p-3 text-sm text-text-success">
-          Settings saved successfully. Changes will appear after the next page load.
+          Settings saved successfully. Changes are now reflected across the app.
         </div>
       )}
 

--- a/tests/api/global-settings/route.put.test.ts
+++ b/tests/api/global-settings/route.put.test.ts
@@ -3,6 +3,7 @@
  */
 import { NextRequest } from "next/server";
 
+jest.mock("next/cache");
 jest.mock("next-auth");
 
 describe("PUT /api/global-settings", () => {
@@ -155,6 +156,25 @@ describe("PUT /api/global-settings", () => {
     expect(response.status).toBe(200);
     expect(body).toEqual({ location1Name: "Arrakeen", location2Name: "Sietch Tabr" });
     expect(mockInsert).toHaveBeenCalledWith({});
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          settingKey: "inventory_location_1_name",
+          settingValue: "Arrakeen",
+        }),
+        expect.objectContaining({
+          settingKey: "inventory_location_2_name",
+          settingValue: "Sietch Tabr",
+        }),
+      ]),
+    );
+    expect(mockOnConflictDoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          lastUpdatedAt: expect.any(Date),
+        }),
+      }),
+    );
   });
 
   it("returns 500 on database failure", async () => {


### PR DESCRIPTION
- Add refreshLocationNames() to LocationNamesContext so consumers can update in-memory names after a save without a page reload
- SettingsForm: initialize inputs with defaults ("Hagga"/"Deep Desert") before fetch, show a non-blocking loadWarning banner on fetch failure, call refreshLocationNames() after a successful PUT
- Tests: add jest.mock("next/cache") to suppress incrementalCache error; assert mockValues and mockOnConflictDoUpdate payloads explicitly
- TransferModal: replace catch (err: any) with standard error coercion pattern (error instanceof Error ? error.message : String(error))
- activity/page.tsx: widen transferDirection type to include new API values; fix direction label logic to map transfer_to_location_2 to location2Name (was falling through to location1Name incorrectly)
- global-settings route: normalize caught error before console.error

https://claude.ai/code/session_01FzLpdAhuS5kXLGojf3BbTr