### PR TITLE
Add 1.5s delay before navigating to duplicated resource

### DIFF
--- a/app/components/DuplicateResourceModal.tsx
+++ b/app/components/DuplicateResourceModal.tsx
@@ -115,6 +115,7 @@ export function DuplicateResourceModal({
       if (!response.ok) {
         throw new Error(data.error ?? "Failed to create resource");
       }
+      await new Promise((resolve) => setTimeout(resolve, 1500));
       onSuccess(data.id);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
Prevents "resource not found" flash caused by cache not yet reflecting the newly created resource when the detail page loads immediately.

https://claude.ai/code/session_01T1mhGUD5mNSE18A5tA6a4g