### PR TITLE
Replace setTimeout with revalidatePath for cache invalidation on create

### DIFF
--- a/app/api/resources/route.ts
+++ b/app/api/resources/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { getServerSession } from "next-auth";
 import { authOptions, getUserIdentifier } from "@/lib/auth";
 import { db, resources, resourceHistory } from "@/lib/db";
@@ -187,6 +188,8 @@ export async function POST(request: NextRequest) {
 
       return inserted;
     });
+
+    revalidatePath("/api/internal/resources");
 
     return NextResponse.json(createdResource, {
       headers: {

--- a/app/components/DuplicateResourceModal.tsx
+++ b/app/components/DuplicateResourceModal.tsx
@@ -115,7 +115,6 @@ export function DuplicateResourceModal({
       if (!response.ok) {
         throw new Error(data.error ?? "Failed to create resource");
       }
-      await new Promise((resolve) => setTimeout(resolve, 1500));
       onSuccess(data.id);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
Call revalidatePath('/api/internal/resources') in the POST handler immediately after the DB transaction, so the Next.js data cache is busted before the client navigates to the new resource. Removes the fragile 1.5s hardcoded delay from DuplicateResourceModal.

https://claude.ai/code/session_01T1mhGUD5mNSE18A5tA6a4g