### PR TITLE
Add retry loop to fetchResource for eventual-consistency resilience

### DIFF
--- a/app/resources/[id]/page.tsx
+++ b/app/resources/[id]/page.tsx
@@ -679,11 +679,26 @@ export default function ResourceDetailPage() {
     }
 
     const fetchResource = async () => {
+      const MAX_ATTEMPTS = 5;
+      const RETRY_DELAY_MS = 1000;
+
       try {
         setLoading(true);
-        const response = await fetch(`/api/resources`);
 
-        if (response.ok) {
+        for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+          if (attempt > 0) {
+            await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+          }
+
+          const response = await fetch(
+            `/api/resources?_t=${Date.now()}`,
+          );
+
+          if (!response.ok) {
+            setError("Failed to fetch resource");
+            return;
+          }
+
           const resources = await response.json();
           const foundResource = resources.find(
             (r: Resource) => r.id === resourceId,
@@ -692,7 +707,6 @@ export default function ResourceDetailPage() {
           if (foundResource) {
             setResource({
               ...foundResource,
-              // Fix date parsing - only convert if it's not already a string
               updatedAt:
                 typeof foundResource.updatedAt === "string"
                   ? foundResource.updatedAt
@@ -702,13 +716,14 @@ export default function ResourceDetailPage() {
                   ? foundResource.createdAt
                   : new Date(foundResource.createdAt).toISOString(),
             });
-            setNewQuantity(foundResource.quantityHagga); // Initialize edit form
+            setNewQuantity(foundResource.quantityHagga);
             setNewQuantityInput(foundResource.quantityHagga.toString());
-          } else {
+            return;
+          }
+
+          if (attempt === MAX_ATTEMPTS - 1) {
             setError("Resource not found");
           }
-        } else {
-          setError("Failed to fetch resource");
         }
       } catch (error) {
         console.error("Error fetching resource:", error);


### PR DESCRIPTION
If the newly created resource isn't present in the first response (cache not yet propagated), retry up to 5 times with 1s between attempts before showing "Resource not found". Each attempt uses a ?_t=<timestamp> query param to bypass browser-level caching. Loading spinner stays visible throughout, so the user sees no flash of error.

https://claude.ai/code/session_01T1mhGUD5mNSE18A5tA6a4g