### PR TITLE
Replace fade-in-up animation with fade-in for PageContainer

### DIFF
--- a/app/components/PageContainer.tsx
+++ b/app/components/PageContainer.tsx
@@ -11,7 +11,7 @@ export function PageContainer({
 }: PageContainerProps) {
   return (
     <main
-      className={`${className} view-transition-content animate-fade-in-up`}
+      className={`${className} view-transition-content animate-fade-in`}
       style={{ viewTransitionName: "page-content" }}
     >
       {children}

--- a/app/globals.css
+++ b/app/globals.css
@@ -615,6 +615,11 @@
   opacity: 0;
 }
 
+.animate-fade-in {
+  animation: fadeIn 0.5s ease-out forwards;
+  opacity: 0;
+}
+
 .animate-fade-in-left {
   animation: fadeInLeft 0.5s ease-out forwards;
   opacity: 0;


### PR DESCRIPTION
## Summary
Updated the PageContainer component to use a simpler fade-in animation instead of the fade-in-up animation, providing a more subtle entrance effect.

## Changes
- Added new `.animate-fade-in` CSS class with a 0.5s ease-out fade animation
- Updated PageContainer to use `animate-fade-in` instead of `animate-fade-in-up`

## Details
The new fade-in animation provides a cleaner, more straightforward entrance effect without the upward movement. This creates a gentler page transition while maintaining the same animation duration and easing curve as the previous implementation.

https://claude.ai/code/session_01Y2QcBZe6errABHEm1sJpkG