### PR TITLE
fix: use opacity-only animation on PageContainer to fix modals on res…

### DIFF
--- a/app/components/PageContainer.tsx
+++ b/app/components/PageContainer.tsx
@@ -11,7 +11,7 @@ export function PageContainer({
 }: PageContainerProps) {
   return (
     <main
-      className={`${className} view-transition-content animate-fade-in-up`}
+      className={`${className} view-transition-content animate-fade-in`}
       style={{ viewTransitionName: "page-content" }}
     >
       {children}

--- a/app/globals.css
+++ b/app/globals.css
@@ -615,6 +615,11 @@
   opacity: 0;
 }
 
+.animate-fade-in {
+  animation: fadeIn 0.5s ease-out forwards;
+  opacity: 0;
+}
+
 .animate-fade-in-left {
   animation: fadeInLeft 0.5s ease-out forwards;
   opacity: 0;


### PR DESCRIPTION
…ources page

fadeInUp leaves transform: translateY(0) via animation-fill-mode: forwards, making <main> a containing block for position: fixed descendants. Modals in ResourceTable (fixed inset-0) were then sized/centered relative to <main> instead of the viewport, placing them off-screen on tall unfiltered tables.

Switch PageContainer to a new animate-fade-in class (opacity only, reuses the existing fadeIn keyframe) so no transform is ever applied to <main>.

https://claude.ai/code/session_01Y2QcBZe6errABHEm1sJpkG