### PR TITLE
Implement sidebar navigation and improved resource history chart

### DIFF
--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -248,7 +248,10 @@ export function AppShell({
         >
           {/* OrgMark + collapse button */}
           <div className="flex items-center justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-2.5">
+            <div
+              className="flex min-w-0 items-center gap-2.5"
+              style={{ justifyContent: collapsed ? "center" : undefined }}
+            >
               <div
                 className="flex shrink-0 items-center justify-center rounded-lg bg-button-primary-bg text-text-white"
                 style={{ width: 32, height: 32 }}
@@ -316,7 +319,7 @@ export function AppShell({
           </nav>
 
           {/* Bottom: theme + user */}
-          <div className="flex flex-col gap-2.5">
+          <div className="flex flex-col items-center gap-2.5">
             <div
               className="flex items-center"
               style={{

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -190,10 +190,10 @@ function UserBadge({ session, collapsed }: UserBadgeProps) {
 
 interface AppShellProps {
   children: ReactNode;
-  title: string;
+  title?: string;
 }
 
-export function AppShell({ children, title }: AppShellProps) {
+export function AppShell({ children, title = process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker" }: AppShellProps) {
   const { data: session } = useSession();
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -21,6 +21,7 @@ import {
 import { ThemeToggle } from "./ThemeToggle";
 import { VersionDisplay } from "./VersionDisplay";
 import { WhatsNewModal } from "./WhatsNewModal";
+import { GiLeechingWorm } from "react-icons/gi";
 
 interface NavItem {
   href: string;
@@ -94,7 +95,9 @@ function SidebarNavItem({ item, active, collapsed }: SidebarNavItemProps) {
         gap: collapsed ? 0 : 12,
         padding: collapsed ? "9px 0" : "9px 12px",
         justifyContent: collapsed ? "center" : "flex-start",
-        background: active ? "color-mix(in srgb, #3b82f6 12%, transparent)" : "transparent",
+        background: active
+          ? "color-mix(in srgb, #3b82f6 12%, transparent)"
+          : "transparent",
         color: active ? "#3b82f6" : undefined,
       }}
     >
@@ -170,10 +173,10 @@ function UserBadge({ session, collapsed }: UserBadgeProps) {
       {!collapsed && (
         <>
           <div className="min-w-0 flex-1">
-            <div className="truncate text-xs font-semibold text-text-primary leading-tight">
+            <div className="truncate text-xs leading-tight font-semibold text-text-primary">
               {displayName}
             </div>
-            <div className="text-[10px] text-text-tertiary mt-0.5">{role}</div>
+            <div className="mt-0.5 text-[10px] text-text-tertiary">{role}</div>
           </div>
           <button
             onClick={() => signOut({ callbackUrl: "/" })}
@@ -193,7 +196,10 @@ interface AppShellProps {
   title?: string;
 }
 
-export function AppShell({ children, title = process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker" }: AppShellProps) {
+export function AppShell({
+  children,
+  title = process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker",
+}: AppShellProps) {
   const { data: session } = useSession();
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
@@ -227,7 +233,7 @@ export function AppShell({ children, title = process.env.NEXT_PUBLIC_ORG_NAME ||
       <div className="flex min-h-screen bg-background-primary transition-colors duration-300">
         {/* ── Desktop sidebar ── */}
         <aside
-          className="hidden md:flex flex-col border-r border-border-primary bg-background-secondary overflow-hidden"
+          className="hidden flex-col overflow-hidden border-r border-border-primary bg-background-secondary md:flex"
           style={{
             width: collapsed ? 68 : 232,
             flexShrink: 0,
@@ -236,21 +242,22 @@ export function AppShell({ children, title = process.env.NEXT_PUBLIC_ORG_NAME ||
             height: "100vh",
             padding: collapsed ? "16px 10px" : "16px 14px",
             gap: 18,
-            transition: "width 220ms cubic-bezier(0.4,0,0.2,1), padding 220ms cubic-bezier(0.4,0,0.2,1)",
+            transition:
+              "width 220ms cubic-bezier(0.4,0,0.2,1), padding 220ms cubic-bezier(0.4,0,0.2,1)",
           }}
         >
           {/* OrgMark + collapse button */}
           <div className="flex items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-2.5">
               <div
-                className="flex shrink-0 items-center justify-center rounded-lg bg-button-primary-bg font-mono text-xs font-bold text-text-white"
+                className="flex shrink-0 items-center justify-center rounded-lg bg-button-primary-bg text-text-white"
                 style={{ width: 32, height: 32 }}
               >
-                RT
+                <GiLeechingWorm size={18} />
               </div>
               {!collapsed && (
                 <div className="min-w-0">
-                  <div className="truncate text-sm font-bold text-text-primary leading-tight">
+                  <div className="truncate text-sm leading-tight font-bold text-text-primary">
                     {title}
                   </div>
                   <VersionDisplay
@@ -288,7 +295,7 @@ export function AppShell({ children, title = process.env.NEXT_PUBLIC_ORG_NAME ||
               <div key={section.label}>
                 {!collapsed ? (
                   <div
-                    className="px-3 pb-2 pt-1 text-[10px] font-semibold uppercase tracking-widest text-text-quaternary"
+                    className="px-3 pt-1 pb-2 text-[10px] font-semibold tracking-widest text-text-quaternary uppercase"
                     style={{ paddingTop: si > 0 ? 14 : 4 }}
                   >
                     {section.label}
@@ -341,10 +348,10 @@ export function AppShell({ children, title = process.env.NEXT_PUBLIC_ORG_NAME ||
               </button>
               <div className="flex items-center gap-2">
                 <div
-                  className="flex items-center justify-center rounded-md bg-button-primary-bg font-mono text-[11px] font-bold text-text-white"
+                  className="flex items-center justify-center rounded-md bg-button-primary-bg text-text-white"
                   style={{ width: 26, height: 26 }}
                 >
-                  RT
+                  <GiLeechingWorm size={14} />
                 </div>
                 <span className="text-sm font-semibold text-text-primary">
                   {currentLabel}
@@ -367,7 +374,7 @@ export function AppShell({ children, title = process.env.NEXT_PUBLIC_ORG_NAME ||
         >
           <div className="absolute inset-0 bg-black/50" />
           <div
-            className="absolute bottom-0 left-0 top-0 flex w-64 flex-col gap-3.5 border-r border-border-primary bg-background-secondary p-4"
+            className="absolute top-0 bottom-0 left-0 flex w-64 flex-col gap-3.5 border-r border-border-primary bg-background-secondary p-4"
             style={{ animation: "slideInFromLeft 180ms ease" }}
             onClick={(e) => e.stopPropagation()}
           >
@@ -375,10 +382,10 @@ export function AppShell({ children, title = process.env.NEXT_PUBLIC_ORG_NAME ||
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2.5">
                 <div
-                  className="flex items-center justify-center rounded-lg bg-button-primary-bg font-mono text-xs font-bold text-text-white"
+                  className="flex items-center justify-center rounded-lg bg-button-primary-bg text-text-white"
                   style={{ width: 32, height: 32 }}
                 >
-                  RT
+                  <GiLeechingWorm size={18} />
                 </div>
                 <div>
                   <div className="text-sm font-bold text-text-primary">
@@ -406,7 +413,7 @@ export function AppShell({ children, title = process.env.NEXT_PUBLIC_ORG_NAME ||
               {NAV_SECTIONS.map((section, si) => (
                 <div key={section.label}>
                   <div
-                    className="px-3 pb-2 text-[10px] font-semibold uppercase tracking-widest text-text-quaternary"
+                    className="px-3 pb-2 text-[10px] font-semibold tracking-widest text-text-quaternary uppercase"
                     style={{ paddingTop: si > 0 ? 14 : 4 }}
                   >
                     {section.label}
@@ -418,7 +425,11 @@ export function AppShell({ children, title = process.env.NEXT_PUBLIC_ORG_NAME ||
                       onClick={() => setDrawerOpen(false)}
                       className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors"
                       style={{
-                        background: isNavItemActive(item.href, pathname, item.exact)
+                        background: isNavItemActive(
+                          item.href,
+                          pathname,
+                          item.exact,
+                        )
                           ? "color-mix(in srgb, #3b82f6 12%, transparent)"
                           : "transparent",
                         color: isNavItemActive(item.href, pathname, item.exact)

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -249,7 +249,7 @@ export function AppShell({
           {/* OrgMark + collapse button */}
           <div className="flex items-center justify-between gap-2">
             <div
-              className="flex min-w-0 items-center gap-2.5"
+              className="flex min-w-0 flex-1 items-center gap-2.5"
               style={{ justifyContent: collapsed ? "center" : undefined }}
             >
               <div
@@ -328,8 +328,8 @@ export function AppShell({
               }}
             >
               {!collapsed && (
-                <span className="text-xs font-medium text-text-tertiary">
-                  Theme
+                <span className="gap-2.5 text-xs font-medium text-text-tertiary">
+                  Theme Switch
                 </span>
               )}
               <ThemeToggle className="h-8 w-8" />

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -161,7 +161,8 @@ function UserBadge({ session, collapsed }: UserBadgeProps) {
         border: collapsed ? "none" : "1px solid",
         borderColor: collapsed ? "transparent" : undefined,
         minWidth: 0,
-        width: collapsed ? 48 : "100%",
+        width: collapsed ? "auto" : "100%",
+        justifyContent: collapsed ? "center" : undefined,
       }}
     >
       <div

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -161,7 +161,7 @@ function UserBadge({ session, collapsed }: UserBadgeProps) {
         border: collapsed ? "none" : "1px solid",
         borderColor: collapsed ? "transparent" : undefined,
         minWidth: 0,
-        width: "100%",
+        width: collapsed ? 48 : "100%",
       }}
     >
       <div

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -321,14 +321,14 @@ export function AppShell({
           {/* Bottom: theme + user */}
           <div className="flex flex-col items-center gap-2.5">
             <div
-              className="flex items-center"
+              className="flex items-center gap-2.5"
               style={{
                 justifyContent: collapsed ? "center" : "space-between",
                 padding: collapsed ? 0 : "0 4px",
               }}
             >
               {!collapsed && (
-                <span className="gap-2.5 text-xs font-medium text-text-tertiary">
+                <span className="text-xs font-medium text-text-tertiary">
                   Theme Switch
                 </span>
               )}

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -1,0 +1,476 @@
+"use client";
+
+import { ReactNode, useState, useEffect } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { signOut } from "next-auth/react";
+import {
+  LayoutDashboard,
+  Layers,
+  Trophy,
+  Activity,
+  Settings,
+  Shield,
+  ChevronLeft,
+  ChevronRight,
+  Menu,
+  X,
+  LogOut,
+} from "lucide-react";
+import { ThemeToggle } from "./ThemeToggle";
+import { VersionDisplay } from "./VersionDisplay";
+import { WhatsNewModal } from "./WhatsNewModal";
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: ReactNode;
+  exact?: boolean;
+}
+
+const NAV_SECTIONS: { label: string; items: NavItem[] }[] = [
+  {
+    label: "Tracker",
+    items: [
+      {
+        href: "/dashboard",
+        label: "Dashboard",
+        icon: <LayoutDashboard size={17} strokeWidth={1.8} />,
+        exact: true,
+      },
+      {
+        href: "/resources",
+        label: "Resources",
+        icon: <Layers size={17} strokeWidth={1.8} />,
+      },
+      {
+        href: "/dashboard/leaderboard",
+        label: "Leaderboard",
+        icon: <Trophy size={17} strokeWidth={1.8} />,
+      },
+      {
+        href: "/dashboard/activity",
+        label: "Activity",
+        icon: <Activity size={17} strokeWidth={1.8} />,
+      },
+    ],
+  },
+  {
+    label: "Account",
+    items: [
+      {
+        href: "/dashboard/settings",
+        label: "Settings",
+        icon: <Settings size={17} strokeWidth={1.8} />,
+      },
+      {
+        href: "/dashboard/privacy",
+        label: "Privacy",
+        icon: <Shield size={17} strokeWidth={1.8} />,
+      },
+    ],
+  },
+];
+
+function isNavItemActive(href: string, pathname: string, exact = false) {
+  if (exact) return pathname === href;
+  return pathname === href || pathname.startsWith(href + "/");
+}
+
+interface SidebarNavItemProps {
+  item: NavItem;
+  active: boolean;
+  collapsed: boolean;
+}
+
+function SidebarNavItem({ item, active, collapsed }: SidebarNavItemProps) {
+  return (
+    <Link
+      href={item.href}
+      title={collapsed ? item.label : undefined}
+      className="relative flex items-center rounded-lg text-sm font-medium transition-colors duration-100"
+      style={{
+        gap: collapsed ? 0 : 12,
+        padding: collapsed ? "9px 0" : "9px 12px",
+        justifyContent: collapsed ? "center" : "flex-start",
+        background: active ? "color-mix(in srgb, #3b82f6 12%, transparent)" : "transparent",
+        color: active ? "#3b82f6" : undefined,
+      }}
+    >
+      {active && !collapsed && (
+        <span
+          className="absolute rounded-full"
+          style={{
+            left: -10,
+            top: 8,
+            bottom: 8,
+            width: 3,
+            background: "#3b82f6",
+          }}
+        />
+      )}
+      <span className={active ? "text-text-link" : "text-text-tertiary"}>
+        {item.icon}
+      </span>
+      {!collapsed && (
+        <span className={active ? "text-text-link" : "text-text-secondary"}>
+          {item.label}
+        </span>
+      )}
+    </Link>
+  );
+}
+
+interface UserBadgeProps {
+  session: ReturnType<typeof useSession>["data"];
+  collapsed: boolean;
+}
+
+function UserBadge({ session, collapsed }: UserBadgeProps) {
+  if (!session?.user) return null;
+
+  const user = session.user as {
+    name?: string;
+    discordNickname?: string;
+    global_name?: string;
+    permissions?: { hasResourceAdminAccess?: boolean };
+  };
+
+  const displayName =
+    user.discordNickname || user.global_name || user.name || "User";
+  const initials = displayName
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase();
+  const isAdmin = user.permissions?.hasResourceAdminAccess;
+  const role = isAdmin ? "Admin" : "Member";
+
+  return (
+    <div
+      className="flex items-center rounded-lg"
+      style={{
+        gap: collapsed ? 0 : 10,
+        padding: collapsed ? 0 : "8px 10px",
+        background: collapsed ? "transparent" : undefined,
+        border: collapsed ? "none" : "1px solid",
+        borderColor: collapsed ? "transparent" : undefined,
+        minWidth: 0,
+      }}
+    >
+      <div
+        className="flex shrink-0 items-center justify-center rounded-full border border-border-primary bg-background-secondary font-mono text-xs font-bold text-text-secondary"
+        style={{ width: 28, height: 28 }}
+        title={displayName}
+      >
+        {initials}
+      </div>
+      {!collapsed && (
+        <>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-xs font-semibold text-text-primary leading-tight">
+              {displayName}
+            </div>
+            <div className="text-[10px] text-text-tertiary mt-0.5">{role}</div>
+          </div>
+          <button
+            onClick={() => signOut({ callbackUrl: "/" })}
+            title="Sign out"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-background-tertiary hover:text-text-secondary"
+          >
+            <LogOut size={14} />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+interface AppShellProps {
+  children: ReactNode;
+  title: string;
+}
+
+export function AppShell({ children, title }: AppShellProps) {
+  const { data: session } = useSession();
+  const pathname = usePathname();
+  const [collapsed, setCollapsed] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [showChangelog, setShowChangelog] = useState(false);
+
+  // Persist collapsed state across page navigations
+  useEffect(() => {
+    const stored = localStorage.getItem("nav-collapsed");
+    if (stored === "true") setCollapsed(true);
+  }, []);
+
+  const toggleCollapsed = () => {
+    const next = !collapsed;
+    setCollapsed(next);
+    localStorage.setItem("nav-collapsed", String(next));
+  };
+
+  // Current page label for mobile header
+  const currentLabel = (() => {
+    for (const section of NAV_SECTIONS) {
+      for (const item of section.items) {
+        if (isNavItemActive(item.href, pathname, item.exact)) return item.label;
+      }
+    }
+    return title;
+  })();
+
+  return (
+    <>
+      <div className="flex min-h-screen bg-background-primary transition-colors duration-300">
+        {/* ── Desktop sidebar ── */}
+        <aside
+          className="hidden md:flex flex-col border-r border-border-primary bg-background-secondary overflow-hidden"
+          style={{
+            width: collapsed ? 68 : 232,
+            flexShrink: 0,
+            position: "sticky",
+            top: 0,
+            height: "100vh",
+            padding: collapsed ? "16px 10px" : "16px 14px",
+            gap: 18,
+            transition: "width 220ms cubic-bezier(0.4,0,0.2,1), padding 220ms cubic-bezier(0.4,0,0.2,1)",
+          }}
+        >
+          {/* OrgMark + collapse button */}
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-2.5">
+              <div
+                className="flex shrink-0 items-center justify-center rounded-lg bg-button-primary-bg font-mono text-xs font-bold text-text-white"
+                style={{ width: 32, height: 32 }}
+              >
+                RT
+              </div>
+              {!collapsed && (
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-bold text-text-primary leading-tight">
+                    {title}
+                  </div>
+                  <VersionDisplay
+                    onClick={() => setShowChangelog(true)}
+                    className="px-0 py-0 text-[10px]"
+                  />
+                </div>
+              )}
+            </div>
+            {!collapsed && (
+              <button
+                onClick={toggleCollapsed}
+                title="Collapse sidebar"
+                className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-border-primary text-text-tertiary transition-colors hover:bg-background-tertiary"
+              >
+                <ChevronLeft size={12} />
+              </button>
+            )}
+          </div>
+
+          {/* Expand button (collapsed state) */}
+          {collapsed && (
+            <button
+              onClick={toggleCollapsed}
+              title="Expand sidebar"
+              className="flex h-6 w-full items-center justify-center rounded-md border border-border-primary text-text-tertiary transition-colors hover:bg-background-tertiary"
+            >
+              <ChevronRight size={12} />
+            </button>
+          )}
+
+          {/* Nav sections */}
+          <nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto">
+            {NAV_SECTIONS.map((section, si) => (
+              <div key={section.label}>
+                {!collapsed ? (
+                  <div
+                    className="px-3 pb-2 pt-1 text-[10px] font-semibold uppercase tracking-widest text-text-quaternary"
+                    style={{ paddingTop: si > 0 ? 14 : 4 }}
+                  >
+                    {section.label}
+                  </div>
+                ) : (
+                  si > 0 && <div style={{ height: 8 }} />
+                )}
+                {section.items.map((item) => (
+                  <SidebarNavItem
+                    key={item.href}
+                    item={item}
+                    active={isNavItemActive(item.href, pathname, item.exact)}
+                    collapsed={collapsed}
+                  />
+                ))}
+              </div>
+            ))}
+          </nav>
+
+          {/* Bottom: theme + user */}
+          <div className="flex flex-col gap-2.5">
+            <div
+              className="flex items-center"
+              style={{
+                justifyContent: collapsed ? "center" : "space-between",
+                padding: collapsed ? 0 : "0 4px",
+              }}
+            >
+              {!collapsed && (
+                <span className="text-xs font-medium text-text-tertiary">
+                  Theme
+                </span>
+              )}
+              <ThemeToggle className="h-8 w-8" />
+            </div>
+            <UserBadge session={session} collapsed={collapsed} />
+          </div>
+        </aside>
+
+        {/* ── Content column ── */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          {/* Mobile top bar */}
+          <header className="sticky top-0 z-30 flex items-center justify-between border-b border-border-primary bg-background-secondary px-4 py-2.5 md:hidden">
+            <div className="flex items-center gap-2.5">
+              <button
+                onClick={() => setDrawerOpen(true)}
+                className="flex h-9 w-9 items-center justify-center rounded-lg border border-border-primary bg-background-tertiary text-text-primary transition-colors hover:bg-background-secondary"
+              >
+                <Menu size={18} />
+              </button>
+              <div className="flex items-center gap-2">
+                <div
+                  className="flex items-center justify-center rounded-md bg-button-primary-bg font-mono text-[11px] font-bold text-text-white"
+                  style={{ width: 26, height: 26 }}
+                >
+                  RT
+                </div>
+                <span className="text-sm font-semibold text-text-primary">
+                  {currentLabel}
+                </span>
+              </div>
+            </div>
+            <ThemeToggle className="h-8 w-8" />
+          </header>
+
+          {/* Page content */}
+          {children}
+        </div>
+      </div>
+
+      {/* ── Mobile drawer overlay ── */}
+      {drawerOpen && (
+        <div
+          className="fixed inset-0 z-50 md:hidden"
+          onClick={() => setDrawerOpen(false)}
+        >
+          <div className="absolute inset-0 bg-black/50" />
+          <div
+            className="absolute bottom-0 left-0 top-0 flex w-64 flex-col gap-3.5 border-r border-border-primary bg-background-secondary p-4"
+            style={{ animation: "slideInFromLeft 180ms ease" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Drawer header */}
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2.5">
+                <div
+                  className="flex items-center justify-center rounded-lg bg-button-primary-bg font-mono text-xs font-bold text-text-white"
+                  style={{ width: 32, height: 32 }}
+                >
+                  RT
+                </div>
+                <div>
+                  <div className="text-sm font-bold text-text-primary">
+                    {title}
+                  </div>
+                  <VersionDisplay
+                    onClick={() => {
+                      setDrawerOpen(false);
+                      setShowChangelog(true);
+                    }}
+                    className="px-0 py-0 text-[10px]"
+                  />
+                </div>
+              </div>
+              <button
+                onClick={() => setDrawerOpen(false)}
+                className="flex h-7 w-7 items-center justify-center rounded-md border border-border-primary text-text-secondary transition-colors hover:bg-background-tertiary"
+              >
+                <X size={14} />
+              </button>
+            </div>
+
+            {/* Drawer nav */}
+            <nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto">
+              {NAV_SECTIONS.map((section, si) => (
+                <div key={section.label}>
+                  <div
+                    className="px-3 pb-2 text-[10px] font-semibold uppercase tracking-widest text-text-quaternary"
+                    style={{ paddingTop: si > 0 ? 14 : 4 }}
+                  >
+                    {section.label}
+                  </div>
+                  {section.items.map((item) => (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      onClick={() => setDrawerOpen(false)}
+                      className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors"
+                      style={{
+                        background: isNavItemActive(item.href, pathname, item.exact)
+                          ? "color-mix(in srgb, #3b82f6 12%, transparent)"
+                          : "transparent",
+                        color: isNavItemActive(item.href, pathname, item.exact)
+                          ? "#3b82f6"
+                          : undefined,
+                      }}
+                    >
+                      <span
+                        className={
+                          isNavItemActive(item.href, pathname, item.exact)
+                            ? "text-text-link"
+                            : "text-text-tertiary"
+                        }
+                      >
+                        {item.icon}
+                      </span>
+                      <span
+                        className={
+                          isNavItemActive(item.href, pathname, item.exact)
+                            ? "text-text-link"
+                            : "text-text-secondary"
+                        }
+                      >
+                        {item.label}
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              ))}
+            </nav>
+
+            {/* Drawer footer */}
+            <UserBadge session={session} collapsed={false} />
+          </div>
+        </div>
+      )}
+
+      {/* Changelog modal */}
+      {showChangelog && (
+        <WhatsNewModal
+          isOpen={showChangelog}
+          onClose={() => setShowChangelog(false)}
+          forceShow={true}
+        />
+      )}
+
+      <style>{`
+        @keyframes slideInFromLeft {
+          from { transform: translateX(-100%); }
+          to { transform: translateX(0); }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -161,6 +161,7 @@ function UserBadge({ session, collapsed }: UserBadgeProps) {
         border: collapsed ? "none" : "1px solid",
         borderColor: collapsed ? "transparent" : undefined,
         minWidth: 0,
+        width: "100%",
       }}
     >
       <div

--- a/app/dashboard/activity/page.tsx
+++ b/app/dashboard/activity/page.tsx
@@ -134,7 +134,7 @@ export default function ActivityLogPage() {
   }
 
   return (
-    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+    <AppShell>
       {/* Main Content */}
       <PageContainer className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="mb-6 flex items-center justify-between">

--- a/app/dashboard/activity/page.tsx
+++ b/app/dashboard/activity/page.tsx
@@ -4,9 +4,9 @@ import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { useLocationNames } from "@/app/context/LocationNamesContext";
 import { PageContainer } from "@/app/components/PageContainer";
+import { AppShell } from "@/app/components/AppShell";
 // Note: hasResourceAccess now computed server-side and available in session.user.permissions
 
 // Utility function to format numbers with commas
@@ -134,44 +134,28 @@ export default function ActivityLogPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background-primary transition-colors duration-300">
-      {/* Header */}
-      <div className="border-b border-border-primary bg-background-secondary shadow-xs">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="flex h-16 items-center justify-between">
-            <div className="flex items-center gap-4">
-              <Link
-                href="/dashboard"
-                className="flex items-center text-text-tertiary transition-colors hover:text-text-primary"
-              >
-                <ArrowLeft className="h-5 w-5 sm:mr-2" />
-                <span className="hidden sm:inline">Back to Dashboard</span>
-              </Link>
-              <div className="h-6 w-px bg-border-secondary"></div>
-              <h1 className="text-xl font-semibold text-text-primary">
-                Your Activity Log
-              </h1>
-            </div>
-            <div className="flex items-center gap-4">
-              <span className="text-sm text-text-tertiary">Time Range:</span>
-              <select
-                value={timeFilter}
-                onChange={(e) => setTimeFilter(parseInt(e.target.value))}
-                className="rounded-sm border border-border-secondary bg-background-primary px-3 py-1 text-sm text-text-primary"
-              >
-                <option value={7}>Last 7 days</option>
-                <option value={14}>Last 14 days</option>
-                <option value={30}>Last 30 days</option>
-                <option value={90}>Last 3 months</option>
-                <option value={365}>Last year</option>
-              </select>
-            </div>
-          </div>
-        </div>
-      </div>
-
+    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
       {/* Main Content */}
       <PageContainer className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-6 flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-text-primary">
+            Your Activity Log
+          </h1>
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-text-tertiary">Time Range:</span>
+            <select
+              value={timeFilter}
+              onChange={(e) => setTimeFilter(parseInt(e.target.value))}
+              className="rounded-sm border border-border-secondary bg-background-primary px-3 py-1 text-sm text-text-primary"
+            >
+              <option value={7}>Last 7 days</option>
+              <option value={14}>Last 14 days</option>
+              <option value={30}>Last 30 days</option>
+              <option value={90}>Last 3 months</option>
+              <option value={365}>Last year</option>
+            </select>
+          </div>
+        </div>
         {loading ? (
           <div className="py-12 text-center">
             <div className="mx-auto h-8 w-8 animate-spin rounded-full border-b-2 border-text-link"></div>
@@ -339,6 +323,6 @@ export default function ActivityLogPage() {
           </div>
         )}
       </PageContainer>
-    </div>
+    </AppShell>
   );
 }

--- a/app/dashboard/contributions/[userId]/page.tsx
+++ b/app/dashboard/contributions/[userId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { Pagination } from "@/app/components/Pagination";
 import { PageContainer } from "@/app/components/PageContainer";
+import { AppShell } from "@/app/components/AppShell";
 
 interface Contribution {
   id: string;
@@ -176,21 +177,21 @@ export default function UserContributionsPage() {
 
   if (loading && !data) {
     return (
-      <div className="min-h-screen bg-background-primary py-8">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+        <div className="flex flex-1 items-center justify-center py-8">
           <div className="text-center">
             <div className="mx-auto h-12 w-12 animate-spin rounded-full border-b-2 border-text-link"></div>
             <p className="mt-4 text-text-tertiary">Loading contributions...</p>
           </div>
         </div>
-      </div>
+      </AppShell>
     );
   }
 
   if (error) {
     return (
-      <div className="min-h-screen bg-background-primary py-8">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+        <div className="flex flex-1 items-center justify-center py-8">
           <div className="text-center">
             <p className="text-text-danger">{error}</p>
             <button
@@ -201,7 +202,7 @@ export default function UserContributionsPage() {
             </button>
           </div>
         </div>
-      </div>
+      </AppShell>
     );
   }
 
@@ -210,8 +211,8 @@ export default function UserContributionsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background-primary py-8">
-      <PageContainer className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+      <PageContainer className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-6 rounded-lg bg-background-panel p-6 shadow-lg">
           <div className="flex items-center justify-between">
@@ -415,6 +416,6 @@ export default function UserContributionsPage() {
           </div>
         </div>
       </PageContainer>
-    </div>
+    </AppShell>
   );
 }

--- a/app/dashboard/contributions/[userId]/page.tsx
+++ b/app/dashboard/contributions/[userId]/page.tsx
@@ -177,7 +177,7 @@ export default function UserContributionsPage() {
 
   if (loading && !data) {
     return (
-      <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+      <AppShell>
         <div className="flex flex-1 items-center justify-center py-8">
           <div className="text-center">
             <div className="mx-auto h-12 w-12 animate-spin rounded-full border-b-2 border-text-link"></div>
@@ -190,7 +190,7 @@ export default function UserContributionsPage() {
 
   if (error) {
     return (
-      <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+      <AppShell>
         <div className="flex flex-1 items-center justify-center py-8">
           <div className="text-center">
             <p className="text-text-danger">{error}</p>
@@ -211,7 +211,7 @@ export default function UserContributionsPage() {
   }
 
   return (
-    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+    <AppShell>
       <PageContainer className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-6 rounded-lg bg-background-panel p-6 shadow-lg">

--- a/app/dashboard/leaderboard/page.tsx
+++ b/app/dashboard/leaderboard/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { Pagination } from "@/app/components/Pagination";
 import { PageContainer } from "@/app/components/PageContainer";
+import { AppShell } from "@/app/components/AppShell";
 
 interface LeaderboardEntry {
   userId: string;
@@ -82,20 +83,20 @@ export default function LeaderboardPage() {
 
   if (loading && !data) {
     return (
-      <div className="min-h-screen bg-background-primary py-8">
-        <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+      <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+        <div className="flex flex-1 items-center justify-center py-8">
           <div className="text-center">
             <div className="mx-auto h-12 w-12 animate-spin rounded-full border-b-2 border-text-link"></div>
             <p className="mt-4 text-text-tertiary">Loading leaderboard...</p>
           </div>
         </div>
-      </div>
+      </AppShell>
     );
   }
 
   return (
-    <div className="min-h-screen bg-background-primary py-8">
-      <PageContainer className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+      <PageContainer className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-6 rounded-lg bg-background-panel p-6 shadow-lg">
           <div className="flex items-center justify-between">
@@ -313,6 +314,6 @@ export default function LeaderboardPage() {
           </div>
         </div>
       </PageContainer>
-    </div>
+    </AppShell>
   );
 }

--- a/app/dashboard/leaderboard/page.tsx
+++ b/app/dashboard/leaderboard/page.tsx
@@ -83,7 +83,7 @@ export default function LeaderboardPage() {
 
   if (loading && !data) {
     return (
-      <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+      <AppShell>
         <div className="flex flex-1 items-center justify-center py-8">
           <div className="text-center">
             <div className="mx-auto h-12 w-12 animate-spin rounded-full border-b-2 border-text-link"></div>
@@ -95,7 +95,7 @@ export default function LeaderboardPage() {
   }
 
   return (
-    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+    <AppShell>
       <PageContainer className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-6 rounded-lg bg-background-panel p-6 shadow-lg">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -22,7 +22,7 @@ export default async function Dashboard() {
   const displayName = getDisplayName(session.user);
 
   return (
-    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+    <AppShell>
       <PageContainer>
         <div className="mx-auto max-w-7xl">
           <header className="mb-8">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,7 +3,7 @@ import { authOptions, getDisplayName } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { RefreshRolesButton } from "../components/RefreshRolesButton";
-import { ClientNavigation } from "../components/ClientNavigation";
+import { AppShell } from "../components/AppShell";
 import { NicknameSettings } from "../components/NicknameSettings";
 import { PageContainer } from "../components/PageContainer";
 
@@ -22,12 +22,7 @@ export default async function Dashboard() {
   const displayName = getDisplayName(session.user);
 
   return (
-    <div className="min-h-screen bg-background-primary transition-colors duration-300">
-      <ClientNavigation
-        title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}
-        showDashboardLink={false}
-      />
-
+    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
       <PageContainer>
         <div className="mx-auto max-w-7xl">
           <header className="mb-8">
@@ -337,6 +332,6 @@ export default async function Dashboard() {
           </div>
         </div>
       </PageContainer>
-    </div>
+    </AppShell>
   );
 }

--- a/app/dashboard/privacy/page.tsx
+++ b/app/dashboard/privacy/page.tsx
@@ -3,11 +3,10 @@
 import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 // Note: hasResourceAccess now computed server-side and available in session.user.permissions
 import { getDisplayName } from "@/lib/auth";
 import { PageContainer } from "@/app/components/PageContainer";
+import { AppShell } from "@/app/components/AppShell";
 
 export default function PrivacyPage() {
   const { data: session, status } = useSession();
@@ -150,29 +149,7 @@ export default function PrivacyPage() {
   const displayName = session ? getDisplayName(session.user) : "User";
 
   return (
-    <div className="min-h-screen bg-background-primary transition-colors duration-300">
-      {/* Header */}
-      <div className="border-b border-border-primary bg-background-secondary shadow-xs">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="flex h-16 items-center justify-between">
-            <div className="flex items-center gap-4">
-              <Link
-                href="/dashboard"
-                className="flex items-center text-text-tertiary transition-colors hover:text-text-primary"
-              >
-                <ArrowLeft className="h-5 w-5 sm:mr-2" />
-                <span className="hidden sm:inline">Back to Dashboard</span>
-              </Link>
-              <div className="h-6 w-px bg-border-secondary"></div>
-              <h1 className="text-xl font-semibold text-text-primary">
-                Privacy & Data
-              </h1>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Content */}
+    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
       <PageContainer className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="space-y-8">
           {/* Welcome */}
@@ -335,6 +312,6 @@ export default function PrivacyPage() {
           </div>
         </div>
       </PageContainer>
-    </div>
+    </AppShell>
   );
 }

--- a/app/dashboard/privacy/page.tsx
+++ b/app/dashboard/privacy/page.tsx
@@ -149,7 +149,7 @@ export default function PrivacyPage() {
   const displayName = session ? getDisplayName(session.user) : "User";
 
   return (
-    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+    <AppShell>
       <PageContainer className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="space-y-8">
           {/* Welcome */}

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { ClientNavigation } from "@/app/components/ClientNavigation";
+import { AppShell } from "@/app/components/AppShell";
 import { PageContainer } from "@/app/components/PageContainer";
 import { SettingsForm } from "./SettingsForm";
 
@@ -17,11 +17,7 @@ export default async function SettingsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background-primary transition-colors duration-300">
-      <ClientNavigation
-        title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}
-        showDashboardLink={true}
-      />
+    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
       <PageContainer>
         <div className="mx-auto max-w-2xl">
           <header className="mb-8">
@@ -35,6 +31,6 @@ export default async function SettingsPage() {
           <SettingsForm />
         </div>
       </PageContainer>
-    </div>
+    </AppShell>
   );
 }

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -17,7 +17,7 @@ export default async function SettingsPage() {
   }
 
   return (
-    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+    <AppShell>
       <PageContainer>
         <div className="mx-auto max-w-2xl">
           <header className="mb-8">

--- a/app/resources/[id]/page.tsx
+++ b/app/resources/[id]/page.tsx
@@ -13,6 +13,8 @@ import { TransferModal } from "@/app/components/TransferModal";
 import { EditResourceModal } from "@/app/components/EditResourceModal";
 import { DuplicateResourceModal } from "@/app/components/DuplicateResourceModal";
 import { PageContainer } from "@/app/components/PageContainer";
+import { AppShell } from "@/app/components/AppShell";
+import { ArrowLeft } from "lucide-react";
 import {
   TIER_OPTIONS,
   UPDATE_TYPE,
@@ -772,18 +774,21 @@ export default function ResourceDetailPage() {
 
   if (loading || sessionStatus === "loading") {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-background-primary">
-        <div className="text-center">
-          <div className="mx-auto h-12 w-12 animate-spin rounded-full border-b-2 border-text-link"></div>
-          <p className="mt-4 text-text-tertiary">Loading resource details...</p>
+      <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+        <div className="flex flex-1 items-center justify-center">
+          <div className="text-center">
+            <div className="mx-auto h-12 w-12 animate-spin rounded-full border-b-2 border-text-link"></div>
+            <p className="mt-4 text-text-tertiary">Loading resource details...</p>
+          </div>
         </div>
-      </div>
+      </AppShell>
     );
   }
 
   if (!resource) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-background-primary">
+      <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+        <div className="flex flex-1 items-center justify-center">
         <div className="text-center">
           <svg
             className="mx-auto mb-4 h-16 w-16 text-text-quaternary"
@@ -820,7 +825,8 @@ export default function ResourceDetailPage() {
             Back to Resources
           </button>
         </div>
-      </div>
+        </div>
+      </AppShell>
     );
   }
 
@@ -837,39 +843,16 @@ export default function ResourceDetailPage() {
     : null;
 
   return (
-    <div className="min-h-screen bg-background-primary transition-colors duration-300">
-      {/* Header */}
-      <div className="border-b border-border-primary bg-background-secondary shadow-xs">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="relative flex h-16 items-center justify-center">
-            <button
-              onClick={() => router.push("/resources")}
-              className="absolute left-0 flex items-center text-text-tertiary transition-colors hover:text-text-primary"
-            >
-              <svg
-                className="h-5 w-5 md:mr-2"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 19l-7-7 7-7"
-                />
-              </svg>
-              <span className="hidden md:inline">Back to Resources</span>
-            </button>
-            <h1 className="text-center text-xl font-semibold text-text-primary">
-              Resource Details
-            </h1>
-          </div>
-        </div>
-      </div>
-
-      {/* Main Content */}
+    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
       <PageContainer className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Breadcrumb */}
+        <button
+          onClick={() => router.push("/resources")}
+          className="mb-6 flex items-center gap-1.5 text-sm text-text-tertiary transition-colors hover:text-text-primary"
+        >
+          <ArrowLeft size={13} />
+          Resources
+        </button>
         <div className="space-y-8">
           {/* Resource Info Card - Full Width Horizontal Layout */}
           <div className="w-full">
@@ -1273,12 +1256,83 @@ export default function ResourceDetailPage() {
             {/* History Chart */}
             {!historyLoading && history.length > 1 && (
               <div className="mb-6 rounded-lg border border-border-secondary bg-background-modal-content-inset p-4">
-                <h4 className="text-md mb-4 font-medium text-text-secondary">
-                  Quantity Over Time
-                </h4>
-                <div className="relative h-72">
+                <div className="mb-3 flex items-start justify-between">
+                  <div>
+                    <h4 className="text-md font-medium text-text-secondary">
+                      Quantity Over Time
+                    </h4>
+                    <p className="mt-0.5 text-xs text-text-quaternary">
+                      Hover points for details · click to highlight · times
+                      update automatically
+                    </p>
+                  </div>
+                </div>
+                <div className="relative">
+                  {(() => {
+                    const reversedHistory = history.slice().reverse();
+                    const W = 860,
+                      H = 260,
+                      PAD_L = 52,
+                      PAD_R = 20,
+                      PAD_T = 24,
+                      PAD_B = 36;
+
+                    const maxV = Math.max(
+                      ...reversedHistory.map(
+                        (p) => p.newQuantityHagga + p.newQuantityDeepDesert,
+                      ),
+                      resource.targetQuantity || 0,
+                      1,
+                    );
+
+                    const xScale = (i: number) =>
+                      PAD_L +
+                      (i / Math.max(reversedHistory.length - 1, 1)) *
+                        (W - PAD_L - PAD_R);
+                    const yScale = (v: number) =>
+                      PAD_T + (1 - v / maxV) * (H - PAD_T - PAD_B);
+
+                    const totalPath = reversedHistory
+                      .map(
+                        (p, i) =>
+                          `${i === 0 ? "M" : "L"}${xScale(i)},${yScale(p.newQuantityHagga + p.newQuantityDeepDesert)}`,
+                      )
+                      .join(" ");
+                    const haggaPath = reversedHistory
+                      .map(
+                        (p, i) =>
+                          `${i === 0 ? "M" : "L"}${xScale(i)},${yScale(p.newQuantityHagga)}`,
+                      )
+                      .join(" ");
+                    const deepPath = reversedHistory
+                      .map(
+                        (p, i) =>
+                          `${i === 0 ? "M" : "L"}${xScale(i)},${yScale(p.newQuantityDeepDesert)}`,
+                      )
+                      .join(" ");
+
+                    const yTicks = [0, 0.25, 0.5, 0.75, 1].map((f) =>
+                      Math.round(maxV * f),
+                    );
+
+                    const xIndices = (() => {
+                      const n = reversedHistory.length;
+                      if (n <= 6) return reversedHistory.map((_, i) => i);
+                      return [
+                        0,
+                        Math.round(n * 0.25),
+                        Math.round(n * 0.5),
+                        Math.round(n * 0.75),
+                        n - 1,
+                      ];
+                    })();
+
+                    return (
+                      <>
                   <svg
-                    className="h-full w-full"
+                          viewBox={`0 0 ${W} ${H}`}
+                          width="100%"
+                          style={{ display: "block", overflow: "visible" }}
                     onMouseMove={(e) => {
                       const rect = e.currentTarget.getBoundingClientRect();
                       setMousePosition({
@@ -1288,144 +1342,131 @@ export default function ResourceDetailPage() {
                     }}
                     onMouseLeave={() => setHoveredPoint(null)}
                   >
-                    {/* Chart Lines and Points */}
-                    {(() => {
-                      const reversedHistory = history.slice().reverse();
+                          {/* Grid lines + Y labels */}
+                          {yTicks.map((v, i) => (
+                            <g key={i}>
+                              <line
+                                x1={PAD_L}
+                                y1={yScale(v)}
+                                x2={W - PAD_R}
+                                y2={yScale(v)}
+                                stroke="#e5e7eb"
+                                strokeDasharray="3 4"
+                                strokeWidth="1"
+                              />
+                              <text
+                                x={PAD_L - 8}
+                                y={yScale(v)}
+                                fill="#9ca3af"
+                                fontSize="10"
+                                textAnchor="end"
+                                dominantBaseline="middle"
+                                fontFamily="ui-monospace,monospace"
+                              >
+                                {formatNumber(v)}
+                              </text>
+                            </g>
+                          ))}
 
-                      const { minQuantity, maxQuantity } = history.reduce(
-                        (acc, h) => {
-                          const total =
-                            h.newQuantityHagga + h.newQuantityDeepDesert;
-                          acc.minQuantity = Math.min(
-                            acc.minQuantity,
-                            h.newQuantityHagga,
-                            h.newQuantityDeepDesert,
-                            total,
-                          );
-                          acc.maxQuantity = Math.max(
-                            acc.maxQuantity,
-                            h.newQuantityHagga,
-                            h.newQuantityDeepDesert,
-                            total,
-                          );
-                          return acc;
-                        },
-                        { minQuantity: Infinity, maxQuantity: -Infinity },
-                      );
-
-                      const range =
-                        maxQuantity !== -Infinity && minQuantity !== Infinity
-                          ? maxQuantity - minQuantity || 1
-                          : 1;
-
-                      return (
-                        <>
-                          {/* Lines */}
-                          {reversedHistory.map((entry, index, arr) => {
-                            if (index === arr.length - 1) return null;
-                            const nextEntry = arr[index + 1];
-
-                            const x1 =
-                              10 + (index / Math.max(arr.length - 1, 1)) * 80;
-                            const x2 =
-                              10 +
-                              ((index + 1) / Math.max(arr.length - 1, 1)) * 80;
-
-                            const y1_total =
-                              80 -
-                              ((entry.newQuantityHagga +
-                                entry.newQuantityDeepDesert -
-                                minQuantity) /
-                                range) *
-                                60;
-                            const y2_total =
-                              80 -
-                              ((nextEntry.newQuantityHagga +
-                                nextEntry.newQuantityDeepDesert -
-                                minQuantity) /
-                                range) *
-                                60;
-                            const y1_hagga =
-                              80 -
-                              ((entry.newQuantityHagga - minQuantity) / range) *
-                                60;
-                            const y2_hagga =
-                              80 -
-                              ((nextEntry.newQuantityHagga - minQuantity) /
-                                range) *
-                                60;
-                            const y1_deep_desert =
-                              80 -
-                              ((entry.newQuantityDeepDesert - minQuantity) /
-                                range) *
-                                60;
-                            const y2_deep_desert =
-                              80 -
-                              ((nextEntry.newQuantityDeepDesert - minQuantity) /
-                                range) *
-                                60;
-
-                            return (
-                              <g key={`line-${entry.id}`}>
+                          {/* Target line */}
+                          {resource.targetQuantity != null &&
+                            resource.targetQuantity > 0 && (
+                              <g>
                                 <line
-                                  x1={`${x1}%`}
-                                  y1={`${y1_total}%`}
-                                  x2={`${x2}%`}
-                                  y2={`${y2_total}%`}
-                                  stroke={CHART_COLORS.total}
-                                  strokeWidth="2"
+                                  x1={PAD_L}
+                                  y1={yScale(resource.targetQuantity)}
+                                  x2={W - PAD_R}
+                                  y2={yScale(resource.targetQuantity)}
+                                  stroke="#f59e0b"
+                                  strokeDasharray="4 4"
+                                  strokeWidth="1.2"
+                                  opacity="0.8"
                                 />
-                                <line
-                                  x1={`${x1}%`}
-                                  y1={`${y1_hagga}%`}
-                                  x2={`${x2}%`}
-                                  y2={`${y2_hagga}%`}
-                                  stroke={CHART_COLORS.hagga}
-                                  strokeWidth="2"
-                                />
-                                <line
-                                  x1={`${x1}%`}
-                                  y1={`${y1_deep_desert}%`}
-                                  x2={`${x2}%`}
-                                  y2={`${y2_deep_desert}%`}
-                                  stroke={CHART_COLORS.deepDesert}
-                                  strokeWidth="2"
-                                />
+                                <text
+                                  x={W - PAD_R}
+                                  y={yScale(resource.targetQuantity) - 6}
+                                  fill="#f59e0b"
+                                  fontSize="10"
+                                  textAnchor="end"
+                                  fontFamily="ui-monospace,monospace"
+                                >
+                                  TARGET ·{" "}
+                                  {formatNumber(resource.targetQuantity)}
+                                </text>
                               </g>
+                            )}
+
+                          {/* X-axis date labels */}
+                          {xIndices.map((i) => {
+                            const entry = reversedHistory[i];
+                            const date = new Date(entry.createdAt);
+                            const label =
+                              date.toLocaleDateString() ===
+                              new Date().toLocaleDateString()
+                                ? date.toLocaleTimeString([], {
+                                    hour: "2-digit",
+                                    minute: "2-digit",
+                                  })
+                                : date.toLocaleDateString([], {
+                                    month: "short",
+                                    day: "numeric",
+                                  });
+                            return (
+                              <text
+                                key={i}
+                                x={xScale(i)}
+                                y={H - 8}
+                                fill="#9ca3af"
+                                fontSize="10"
+                                textAnchor="middle"
+                              >
+                                {label}
+                              </text>
                             );
                           })}
-                          {/* Points */}
-                          {reversedHistory.map((entry, index, arr) => {
-                            const x =
-                              10 + (index / Math.max(arr.length - 1, 1)) * 80;
-                            const y_total =
-                              80 -
-                              ((entry.newQuantityHagga +
-                                entry.newQuantityDeepDesert -
-                                minQuantity) /
-                                range) *
-                                60;
-                            const y_hagga =
-                              80 -
-                              ((entry.newQuantityHagga - minQuantity) / range) *
-                                60;
-                            const y_deep_desert =
-                              80 -
-                              ((entry.newQuantityDeepDesert - minQuantity) /
-                                range) *
-                                60;
 
+                          {/* Series paths */}
+                          <path
+                            d={totalPath}
+                            fill="none"
+                            stroke={CHART_COLORS.total}
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                          <path
+                            d={haggaPath}
+                            fill="none"
+                            stroke={CHART_COLORS.hagga}
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                          <path
+                            d={deepPath}
+                            fill="none"
+                            stroke={CHART_COLORS.deepDesert}
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+
+                          {/* Data points */}
+                          {reversedHistory.map((entry, i) => {
+                            const x = xScale(i);
+                            const yTotal = yScale(
+                              entry.newQuantityHagga +
+                                entry.newQuantityDeepDesert,
+                            );
+                            const yHagga = yScale(entry.newQuantityHagga);
+                            const yDeep = yScale(entry.newQuantityDeepDesert);
                             const isSelected = selectedPointId === entry.id;
                             const isHovered = hoveredPoint?.id === entry.id;
-                            const pointRadius = isSelected
-                              ? "6"
-                              : isHovered
-                                ? "5"
-                                : "4";
+                            const r = isSelected ? 5 : isHovered ? 4 : 3;
 
                             return (
                               <g
-                                key={`point-group-${entry.id}`}
+                                key={entry.id}
                                 onMouseEnter={() => setHoveredPoint(entry)}
                                 onMouseLeave={() => setHoveredPoint(null)}
                                 onClick={() =>
@@ -1438,116 +1479,35 @@ export default function ResourceDetailPage() {
                                 className="cursor-pointer"
                               >
                                 <circle
-                                  cx={`${x}%`}
-                                  cy={`${y_total}%`}
-                                  r={pointRadius}
-                                  fill={CHART_COLORS.total}
-                                  stroke={
-                                    isSelected ? CHART_COLORS.total : "white"
-                                  }
-                                  strokeWidth="2"
+                                  cx={x}
+                                  cy={yTotal}
+                                  r={r}
+                                  fill="white"
+                                  stroke={CHART_COLORS.total}
+                                  strokeWidth="1.5"
                                 />
                                 <circle
-                                  cx={`${x}%`}
-                                  cy={`${y_hagga}%`}
-                                  r={pointRadius}
-                                  fill={CHART_COLORS.hagga}
-                                  stroke={
-                                    isSelected ? CHART_COLORS.hagga : "white"
-                                  }
-                                  strokeWidth="2"
+                                  cx={x}
+                                  cy={yHagga}
+                                  r={r}
+                                  fill="white"
+                                  stroke={CHART_COLORS.hagga}
+                                  strokeWidth="1.5"
                                 />
                                 <circle
-                                  cx={`${x}%`}
-                                  cy={`${y_deep_desert}%`}
-                                  r={pointRadius}
-                                  fill={CHART_COLORS.deepDesert}
-                                  stroke={
-                                    isSelected
-                                      ? CHART_COLORS.deepDesert
-                                      : "white"
-                                  }
-                                  strokeWidth="2"
+                                  cx={x}
+                                  cy={yDeep}
+                                  r={r}
+                                  fill="white"
+                                  stroke={CHART_COLORS.deepDesert}
+                                  strokeWidth="1.5"
                                 />
                               </g>
                             );
                           })}
-                          {/* Y-axis labels */}
-                          {Array.from({ length: 4 }).map((_, i) => {
-                            const numLabels = 4;
-                            const value =
-                              minQuantity + (range / (numLabels - 1)) * i;
-                            const y = 80 - ((value - minQuantity) / range) * 60;
-                            return (
-                              <text
-                                key={i}
-                                x="0"
-                                y={`${y}%`}
-                                dominant-baseline="middle"
-                                fontSize="10"
-                                fill="#6b7280"
-                                className="text-xs"
-                                textAnchor="start"
-                              >
-                                {formatNumber(Math.round(value))}
-                              </text>
-                            );
-                          })}
-                        </>
-                      );
-                    })()}
-
-                    {/* X-axis time labels */}
-                    {history.length > 1 &&
-                      history
-                        .slice()
-                        .reverse()
-                        .map((entry, index, arr) => {
-                          if (
-                            index % Math.max(1, Math.floor(arr.length / 4)) !==
-                              0 &&
-                            index !== arr.length - 1
-                          )
-                            return null;
-
-                          const x =
-                            10 + (index / Math.max(arr.length - 1, 1)) * 80;
-                          const date = new Date(entry.createdAt);
-                          const timeLabel =
-                            date.toLocaleDateString() ===
-                            new Date().toLocaleDateString()
-                              ? date.toLocaleTimeString([], {
-                                  hour: "2-digit",
-                                  minute: "2-digit",
-                                })
-                              : date.toLocaleDateString([], {
-                                  month: "short",
-                                  day: "numeric",
-                                });
-
-                          const isHovered = hoveredPoint?.id === entry.id;
-                          const isSelected = selectedPointId === entry.id;
-
-                          return (
-                            <text
-                              key={`time-${entry.id}`}
-                              x={`${x}%`}
-                              y="98%"
-                              fontSize="9"
-                              fill="#6b7280"
-                              fontWeight={
-                                isHovered || isSelected ? "bold" : "normal"
-                              }
-                              className="text-xs transition-all"
-                              textAnchor="middle"
-                            >
-                              {timeLabel}
-                            </text>
-                          );
-                        })}
                   </svg>
 
-                  {/* Hover Tooltip */}
+                        {/* Hover tooltip */}
                   {hoveredPoint && (
                     <div
                       className="pointer-events-none absolute z-10 rounded-sm bg-background-tooltip px-2 py-1 text-xs whitespace-nowrap text-text-tooltip"
@@ -1586,36 +1546,38 @@ export default function ResourceDetailPage() {
                       </div>
                     </div>
                   )}
+                      </>
+                    );
+                  })()}
                 </div>
-                <div className="mt-4 flex items-center justify-center gap-6 text-xs text-text-tertiary">
-                  <div className="flex items-center gap-1">
-                    <div
-                      className="h-3 w-3 flex-shrink-0 rounded-full"
+
+                {/* Legend */}
+                <div className="mt-3 flex flex-wrap items-center justify-center gap-4 text-xs text-text-secondary">
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full"
                       style={{ backgroundColor: CHART_COLORS.total }}
-                    ></div>
-                    <span>Total</span>
+                    />
+                    Total
                   </div>
-                  <div className="flex items-center gap-1">
-                    <div
-                      className="h-3 w-3 flex-shrink-0 rounded-full"
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full"
                       style={{ backgroundColor: CHART_COLORS.hagga }}
-                    ></div>
-                    <span>{location1Name}</span>
+                    />
+                    {location1Name}
                   </div>
-                  <div className="flex items-center gap-1">
-                    <div
-                      className="h-3 w-3 flex-shrink-0 rounded-full"
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full"
                       style={{ backgroundColor: CHART_COLORS.deepDesert }}
-                    ></div>
-                    <span>{location2Name}</span>
-                  </div>
-                  <div className="ml-4 text-text-quaternary">
-                    💡 Hover points for details, click to highlight below •
-                    Times update automatically
+                    />
+                    {location2Name}
                   </div>
                 </div>
               </div>
             )}
+
 
             {!historyLoading && history.length <= 1 && (
               <div className="py-8 text-center text-text-quaternary">
@@ -2160,6 +2122,6 @@ export default function ResourceDetailPage() {
           </div>
         </div>
       )}
-    </div>
+    </AppShell>
   );
 }

--- a/app/resources/[id]/page.tsx
+++ b/app/resources/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { ResourceHistoryChart } from "@/app/components/ResourceHistoryChart";
@@ -52,6 +52,13 @@ const CHART_COLORS = {
   hagga: "#10b981",
   deepDesert: "#f97316",
 };
+
+const CHART_W = 860;
+const CHART_H = 260;
+const CHART_PAD_L = 52;
+const CHART_PAD_R = 20;
+const CHART_PAD_T = 24;
+const CHART_PAD_B = 36;
 
 // Utility function to format numbers with commas
 const formatNumber = (num: number): string => {
@@ -217,6 +224,37 @@ export default function ResourceDetailPage() {
   // Check if user can delete history entries
   const isResourceAdmin =
     session?.user?.permissions?.hasResourceAdminAccess ?? false;
+
+  const chartData = useMemo(() => {
+    if (history.length <= 1) return null;
+    const reversedHistory = history.slice().reverse();
+    const maxV = Math.max(
+      ...reversedHistory.map((p) => p.newQuantityHagga + p.newQuantityDeepDesert),
+      resource?.targetQuantity || 0,
+      1,
+    );
+    const xScale = (i: number) =>
+      CHART_PAD_L + (i / Math.max(reversedHistory.length - 1, 1)) * (CHART_W - CHART_PAD_L - CHART_PAD_R);
+    const yScale = (v: number) =>
+      CHART_PAD_T + (1 - v / maxV) * (CHART_H - CHART_PAD_T - CHART_PAD_B);
+    const totalPath = reversedHistory
+      .map((p, i) => `${i === 0 ? "M" : "L"}${xScale(i)},${yScale(p.newQuantityHagga + p.newQuantityDeepDesert)}`)
+      .join(" ");
+    const haggaPath = reversedHistory
+      .map((p, i) => `${i === 0 ? "M" : "L"}${xScale(i)},${yScale(p.newQuantityHagga)}`)
+      .join(" ");
+    const deepPath = reversedHistory
+      .map((p, i) => `${i === 0 ? "M" : "L"}${xScale(i)},${yScale(p.newQuantityDeepDesert)}`)
+      .join(" ");
+    const yTicks = [0, 0.25, 0.5, 0.75, 1].map((f) => Math.round(maxV * f));
+    const n = reversedHistory.length;
+    const xIndices =
+      n <= 6
+        ? reversedHistory.map((_, i) => i)
+        : [0, Math.round(n * 0.25), Math.round(n * 0.5), Math.round(n * 0.75), n - 1];
+    const todayStr = new Date().toLocaleDateString();
+    return { reversedHistory, maxV, xScale, yScale, totalPath, haggaPath, deepPath, yTicks, xIndices, todayStr };
+  }, [history, resource?.targetQuantity]);
 
   // Admin function to start editing a resource
   const startEditResource = (resource: Resource) => {
@@ -774,7 +812,7 @@ export default function ResourceDetailPage() {
 
   if (loading || sessionStatus === "loading") {
     return (
-      <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+      <AppShell>
         <div className="flex flex-1 items-center justify-center">
           <div className="text-center">
             <div className="mx-auto h-12 w-12 animate-spin rounded-full border-b-2 border-text-link"></div>
@@ -787,7 +825,7 @@ export default function ResourceDetailPage() {
 
   if (!resource) {
     return (
-      <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+      <AppShell>
         <div className="flex flex-1 items-center justify-center">
         <div className="text-center">
           <svg
@@ -843,7 +881,7 @@ export default function ResourceDetailPage() {
     : null;
 
   return (
-    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+    <AppShell>
       <PageContainer className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         {/* Breadcrumb */}
         <button
@@ -1254,7 +1292,7 @@ export default function ResourceDetailPage() {
             </div>
 
             {/* History Chart */}
-            {!historyLoading && history.length > 1 && (
+            {!historyLoading && chartData && (
               <div className="mb-6 rounded-lg border border-border-secondary bg-background-modal-content-inset p-4">
                 <div className="mb-3 flex items-start justify-between">
                   <div>
@@ -1268,69 +1306,12 @@ export default function ResourceDetailPage() {
                   </div>
                 </div>
                 <div className="relative">
-                  {(() => {
-                    const reversedHistory = history.slice().reverse();
-                    const W = 860,
-                      H = 260,
-                      PAD_L = 52,
-                      PAD_R = 20,
-                      PAD_T = 24,
-                      PAD_B = 36;
-
-                    const maxV = Math.max(
-                      ...reversedHistory.map(
-                        (p) => p.newQuantityHagga + p.newQuantityDeepDesert,
-                      ),
-                      resource.targetQuantity || 0,
-                      1,
-                    );
-
-                    const xScale = (i: number) =>
-                      PAD_L +
-                      (i / Math.max(reversedHistory.length - 1, 1)) *
-                        (W - PAD_L - PAD_R);
-                    const yScale = (v: number) =>
-                      PAD_T + (1 - v / maxV) * (H - PAD_T - PAD_B);
-
-                    const totalPath = reversedHistory
-                      .map(
-                        (p, i) =>
-                          `${i === 0 ? "M" : "L"}${xScale(i)},${yScale(p.newQuantityHagga + p.newQuantityDeepDesert)}`,
-                      )
-                      .join(" ");
-                    const haggaPath = reversedHistory
-                      .map(
-                        (p, i) =>
-                          `${i === 0 ? "M" : "L"}${xScale(i)},${yScale(p.newQuantityHagga)}`,
-                      )
-                      .join(" ");
-                    const deepPath = reversedHistory
-                      .map(
-                        (p, i) =>
-                          `${i === 0 ? "M" : "L"}${xScale(i)},${yScale(p.newQuantityDeepDesert)}`,
-                      )
-                      .join(" ");
-
-                    const yTicks = [0, 0.25, 0.5, 0.75, 1].map((f) =>
-                      Math.round(maxV * f),
-                    );
-
-                    const xIndices = (() => {
-                      const n = reversedHistory.length;
-                      if (n <= 6) return reversedHistory.map((_, i) => i);
-                      return [
-                        0,
-                        Math.round(n * 0.25),
-                        Math.round(n * 0.5),
-                        Math.round(n * 0.75),
-                        n - 1,
-                      ];
-                    })();
-
+                  {chartData && (() => {
+                    const { reversedHistory, xScale, yScale, totalPath, haggaPath, deepPath, yTicks, xIndices, todayStr } = chartData;
                     return (
                       <>
                   <svg
-                          viewBox={`0 0 ${W} ${H}`}
+                          viewBox={`0 0 ${CHART_W} ${CHART_H}`}
                           width="100%"
                           style={{ display: "block", overflow: "visible" }}
                     onMouseMove={(e) => {
@@ -1346,16 +1327,16 @@ export default function ResourceDetailPage() {
                           {yTicks.map((v, i) => (
                             <g key={i}>
                               <line
-                                x1={PAD_L}
+                                x1={CHART_PAD_L}
                                 y1={yScale(v)}
-                                x2={W - PAD_R}
+                                x2={CHART_W - CHART_PAD_R}
                                 y2={yScale(v)}
                                 stroke="#e5e7eb"
                                 strokeDasharray="3 4"
                                 strokeWidth="1"
                               />
                               <text
-                                x={PAD_L - 8}
+                                x={CHART_PAD_L - 8}
                                 y={yScale(v)}
                                 fill="#9ca3af"
                                 fontSize="10"
@@ -1373,9 +1354,9 @@ export default function ResourceDetailPage() {
                             resource.targetQuantity > 0 && (
                               <g>
                                 <line
-                                  x1={PAD_L}
+                                  x1={CHART_PAD_L}
                                   y1={yScale(resource.targetQuantity)}
-                                  x2={W - PAD_R}
+                                  x2={CHART_W - CHART_PAD_R}
                                   y2={yScale(resource.targetQuantity)}
                                   stroke="#f59e0b"
                                   strokeDasharray="4 4"
@@ -1383,7 +1364,7 @@ export default function ResourceDetailPage() {
                                   opacity="0.8"
                                 />
                                 <text
-                                  x={W - PAD_R}
+                                  x={CHART_W - CHART_PAD_R}
                                   y={yScale(resource.targetQuantity) - 6}
                                   fill="#f59e0b"
                                   fontSize="10"
@@ -1401,8 +1382,7 @@ export default function ResourceDetailPage() {
                             const entry = reversedHistory[i];
                             const date = new Date(entry.createdAt);
                             const label =
-                              date.toLocaleDateString() ===
-                              new Date().toLocaleDateString()
+                              date.toLocaleDateString() === todayStr
                                 ? date.toLocaleTimeString([], {
                                     hour: "2-digit",
                                     minute: "2-digit",
@@ -1415,7 +1395,7 @@ export default function ResourceDetailPage() {
                               <text
                                 key={i}
                                 x={xScale(i)}
-                                y={H - 8}
+                                y={CHART_H - 8}
                                 fill="#9ca3af"
                                 fontSize="10"
                                 textAnchor="middle"
@@ -1579,7 +1559,7 @@ export default function ResourceDetailPage() {
             )}
 
 
-            {!historyLoading && history.length <= 1 && (
+            {!historyLoading && !chartData && (
               <div className="py-8 text-center text-text-quaternary">
                 <svg
                   className="mx-auto mb-4 h-12 w-12 text-text-quaternary"

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -17,7 +17,7 @@ export default async function ResourcesPage() {
   }
 
   return (
-    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+    <AppShell>
       <PageContainer>
         <div className="mx-auto max-w-7xl">
           <header className="mb-8">

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { ClientNavigation } from "../components/ClientNavigation";
+import { AppShell } from "../components/AppShell";
 import { PageContainer } from "../components/PageContainer";
 import { ResourceTable } from "../components/ResourceTable";
 
@@ -17,12 +17,7 @@ export default async function ResourcesPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background-primary transition-colors duration-300">
-      <ClientNavigation
-        title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}
-        showDashboardLink={true}
-      />
-
+    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
       <PageContainer>
         <div className="mx-auto max-w-7xl">
           <header className="mb-8">
@@ -40,6 +35,6 @@ export default async function ResourcesPage() {
           />
         </div>
       </PageContainer>
-    </div>
+    </AppShell>
   );
 }

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { ClientNavigation } from "../components/ClientNavigation";
+import { AppShell } from "../components/AppShell";
 import { PageContainer } from "../components/PageContainer";
 import { UserTable } from "../components/UserTable";
 
@@ -17,12 +17,7 @@ export default async function UsersPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background-primary transition-colors duration-300">
-      <ClientNavigation
-        title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}
-        showDashboardLink={true}
-      />
-
+    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
       <PageContainer>
         <div className="mx-auto max-w-7xl">
           <header className="mb-8">
@@ -35,6 +30,6 @@ export default async function UsersPage() {
           <UserTable />
         </div>
       </PageContainer>
-    </div>
+    </AppShell>
   );
 }

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -17,7 +17,7 @@ export default async function UsersPage() {
   }
 
   return (
-    <AppShell title={process.env.NEXT_PUBLIC_ORG_NAME || "Resource Tracker"}>
+    <AppShell>
       <PageContainer>
         <div className="mx-auto max-w-7xl">
           <header className="mb-8">

--- a/lib/changelog.json
+++ b/lib/changelog.json
@@ -1,6 +1,22 @@
 {
-  "currentVersion": "4.3.0",
+  "currentVersion": "4.4.0",
   "releases": [
+    {
+      "version": "4.4.0",
+      "date": "2026-04-24",
+      "title": "Sidebar Navigation & Improved Resource History Chart",
+      "type": "minor",
+      "changes": [
+        {
+          "type": "feature",
+          "description": "Replaced the top navigation bar with a collapsible sidebar on desktop and a slide-out drawer on mobile. The sidebar provides consistent navigation to Dashboard, Resources, Leaderboard, Activity, Settings, and Privacy from every page."
+        },
+        {
+          "type": "improvement",
+          "description": "Improved the Resource Details quantity-over-time chart with a proper coordinate system (viewBox), dashed grid lines, Y-axis labels, X-axis date labels, a dashed target line, path-based series rendering, and a legend below the chart."
+        }
+      ]
+    },
     {
       "version": "4.3.0",
       "date": "2026-04-19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@libsql/client": "^0.17.2",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
-        "lucide-react": "^1.7.0",
+        "lucide-react": "^1.9.0",
         "nanoid": "^5.1.9",
         "next": "15.5.15",
         "next-auth": "^4.24.13",
@@ -9780,9 +9780,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
-      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.9.0.tgz",
+      "integrity": "sha512-6qVAmbgCjcJz7sAGSPSSJ++RAwjlK2XCbRrZKv63Ciko1KT8jX0//CXxgI3jg2HlJu8tADqdYlNDebmYjeoruA==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@eslint/eslintrc": "^3.3.3",
         "@playwright/test": "^1.59.1",
         "@swc/jest": "^0.2.39",
-        "@tailwindcss/postcss": "^4.2.2",
+        "@tailwindcss/postcss": "^4.2.4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -50,7 +50,7 @@
         "tailwindcss": "^4.2.4",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2",
-        "typescript-eslint": "^8.46.0"
+        "typescript-eslint": "^8.59.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3436,9 +3436,9 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
-      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
+      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3448,44 +3448,37 @@
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.2"
+        "tailwindcss": "4.2.4"
       }
     },
-    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
-      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
+      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.2",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
-        "@tailwindcss/oxide-darwin-x64": "4.2.2",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+        "@tailwindcss/oxide-android-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-x64": "4.2.4",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
-      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
+      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
       "cpu": [
         "arm64"
       ],
@@ -3500,9 +3493,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
-      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
+      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
       "cpu": [
         "arm64"
       ],
@@ -3517,9 +3510,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
-      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
+      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
       "cpu": [
         "x64"
       ],
@@ -3534,9 +3527,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
-      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
+      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
       "cpu": [
         "x64"
       ],
@@ -3551,9 +3544,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
-      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
+      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
       "cpu": [
         "arm"
       ],
@@ -3568,9 +3561,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
-      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
+      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
       "cpu": [
         "arm64"
       ],
@@ -3585,9 +3578,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
-      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
+      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
       "cpu": [
         "arm64"
       ],
@@ -3602,9 +3595,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
-      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
       "cpu": [
         "x64"
       ],
@@ -3619,9 +3612,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
-      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
+      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
       "cpu": [
         "x64"
       ],
@@ -3636,9 +3629,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
-      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
+      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -3730,9 +3723,9 @@
       "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
-      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
+      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
       "cpu": [
         "arm64"
       ],
@@ -3747,9 +3740,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
-      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
+      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
       "cpu": [
         "x64"
       ],
@@ -3764,25 +3757,18 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
-      "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.4.tgz",
+      "integrity": "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.2.2",
-        "@tailwindcss/oxide": "4.2.2",
+        "@tailwindcss/node": "4.2.4",
+        "@tailwindcss/oxide": "4.2.4",
         "postcss": "^8.5.6",
-        "tailwindcss": "4.2.2"
+        "tailwindcss": "4.2.4"
       }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/tailwindcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tanstack/react-virtual": {
       "version": "3.13.23",
@@ -4148,17 +4134,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
-      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/type-utils": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -4171,7 +4157,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.2",
+        "@typescript-eslint/parser": "^8.59.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -4187,16 +4173,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
-      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4212,14 +4198,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.2",
-        "@typescript-eslint/types": "^8.58.2",
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4234,14 +4220,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2"
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4252,9 +4238,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4269,15 +4255,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
-      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -4294,9 +4280,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4308,16 +4294,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.2",
-        "@typescript-eslint/tsconfig-utils": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4375,16 +4361,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2"
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4399,13 +4385,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/types": "8.59.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -6062,14 +6048,14 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -12084,9 +12070,9 @@
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12905,16 +12891,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
-      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
+      "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.2",
-        "@typescript-eslint/parser": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2"
+        "@typescript-eslint/eslint-plugin": "8.59.0",
+        "@typescript-eslint/parser": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@headlessui/react": "^2.2.10",
-        "@libsql/client": "^0.17.2",
+        "@libsql/client": "^0.17.3",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
         "lucide-react": "^1.9.0",
@@ -2619,22 +2619,22 @@
       }
     },
     "node_modules/@libsql/client": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.2.tgz",
-      "integrity": "sha512-0aw0S3iQMHvOxfRt5j1atoCCPMT3gjsB2PS8/uxSM1DcDn39xqz6RlgSMxtP8I3JsxIXAFuw7S41baLEw0Zi+Q==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.3.tgz",
+      "integrity": "sha512-HXk9wiAoJbKFbyBH4O+aEhN6ir5ERXuXvwE5OD2eR4/5RUa3Pw/8L9zrnVdU+iNJitRvisPWaIwmhkO3bH7giA==",
       "license": "MIT",
       "dependencies": {
-        "@libsql/core": "^0.17.2",
-        "@libsql/hrana-client": "^0.9.0",
+        "@libsql/core": "^0.17.3",
+        "@libsql/hrana-client": "^0.10.0",
         "js-base64": "^3.7.5",
         "libsql": "^0.5.28",
         "promise-limit": "^2.7.0"
       }
     },
     "node_modules/@libsql/core": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.17.2.tgz",
-      "integrity": "sha512-L8qv12HZ/jRBcETVR3rscP0uHNxh+K3EABSde6scCw7zfOdiLqO3MAkJaeE1WovPsjXzsN/JBoZED4+7EZVT3g==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.17.3.tgz",
+      "integrity": "sha512-2UjK1i7JBkMduJo4WdvvBxMMvVJ31pArBZNONyz/GCJJAH+1UHat2X6vn10S/WpY5fKzIT98WqYFl2vzWRLOfg==",
       "license": "MIT",
       "dependencies": {
         "js-base64": "^3.7.5"
@@ -2667,15 +2667,13 @@
       ]
     },
     "node_modules/@libsql/hrana-client": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.9.0.tgz",
-      "integrity": "sha512-pxQ1986AuWfPX4oXzBvLwBnfgKDE5OMhAdR/5cZmRaB4Ygz5MecQybvwZupnRz341r2CtFmbk/BhSu7k2Lm+Jw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.10.0.tgz",
+      "integrity": "sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw==",
       "license": "MIT",
       "dependencies": {
         "@libsql/isomorphic-ws": "^0.1.5",
-        "cross-fetch": "^4.0.0",
-        "js-base64": "^3.7.5",
-        "node-fetch": "^3.3.2"
+        "js-base64": "^3.7.5"
       }
     },
     "node_modules/@libsql/isomorphic-ws": {
@@ -5523,57 +5521,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
-    "node_modules/cross-fetch/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/cross-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/cross-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/cross-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5628,6 +5575,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -7010,6 +6958,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7130,6 +7079,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
@@ -10131,6 +10081,7 @@
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10179,6 +10130,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -13075,6 +13027,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "node-fetch": "^3.3.2",
         "postcss": "^8.5.10",
         "prettier": "^3.8.3",
-        "prettier-plugin-tailwindcss": "^0.7.2",
+        "prettier-plugin-tailwindcss": "^0.7.3",
         "tailwindcss": "^4.2.4",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2",
@@ -10897,9 +10897,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.7.2.tgz",
-      "integrity": "sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.7.3.tgz",
+      "integrity": "sha512-lckXaWWdo2ZVXoMoUO3WIBiz9hVY+YBEh1gYyMFfrWP9WZW/wpFXQKizHx7WrFQFMkcG0bGShdpp531X1n+qpg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     "tailwindcss": "^4.2.4",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
-    "typescript-eslint": "^8.46.0"
+    "typescript-eslint": "^8.59.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@libsql/client": "^0.17.2",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
-    "lucide-react": "^1.7.0",
+    "lucide-react": "^1.9.0",
     "nanoid": "^5.1.9",
     "next": "15.5.15",
     "next-auth": "^4.24.13",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",
     "@headlessui/react": "^2.2.10",
-    "@libsql/client": "^0.17.2",
+    "@libsql/client": "^0.17.3",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
     "lucide-react": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "node-fetch": "^3.3.2",
     "postcss": "^8.5.10",
     "prettier": "^3.8.3",
-    "prettier-plugin-tailwindcss": "^0.7.2",
+    "prettier-plugin-tailwindcss": "^0.7.3",
     "tailwindcss": "^4.2.4",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",


### PR DESCRIPTION
- New AppShell component replaces ClientNavigation across all protected pages. Desktop renders a collapsible sticky sidebar (232px/68px) with two nav sections (Tracker: Dashboard, Resources, Leaderboard, Activity; Account: Settings, Privacy), theme toggle, and user badge with logout. Mobile renders a sticky top bar with a slide-out hamburger drawer.

- Collapsed state is persisted to localStorage; active nav item is detected from the current pathname.

- Resource Details page custom header replaced by AppShell; a small breadcrumb "← Resources" button now sits at the top of the content area.

- Chart in Resource Details upgraded: proper viewBox coordinate system (860×260 with explicit padding), dashed grid lines, Y-axis monospace labels, X-axis date labels, dashed target line with label, path-based series rendering, circles with white fill / colored stroke, and a legend row below the chart.

- Changelog bumped to v4.4.0.

https://claude.ai/code/session_01Xhe7dyYA8frsqrbf3NatW4