### PR TITLE
Replace hardcoded chart colors with CSS variables

### DIFF
--- a/app/components/ResourceHistoryChart.tsx
+++ b/app/components/ResourceHistoryChart.tsx
@@ -196,7 +196,7 @@ export function ResourceHistoryChart({
                                 y1={`${y1}%`}
                                 x2={`${x2}%`}
                                 y2={`${y2}%`}
-                                stroke="#3b82f6"
+                                stroke="var(--color-chart-line)"
                                 strokeWidth="2"
                               />
                             );
@@ -230,7 +230,7 @@ export function ResourceHistoryChart({
                                 cx={`${x}%`}
                                 cy={`${y}%`}
                                 r="4"
-                                fill="#3b82f6"
+                                fill="var(--color-chart-line)"
                                 stroke="var(--color-chart-point-fill)"
                                 strokeWidth="2"
                                 className="hover:r-6 cursor-pointer transition-all"

--- a/app/components/ResourceHistoryChart.tsx
+++ b/app/components/ResourceHistoryChart.tsx
@@ -231,7 +231,7 @@ export function ResourceHistoryChart({
                                 cy={`${y}%`}
                                 r="4"
                                 fill="#3b82f6"
-                                stroke="white"
+                                stroke="var(--color-chart-point-fill)"
                                 strokeWidth="2"
                                 className="hover:r-6 cursor-pointer transition-all"
                                 onMouseEnter={() => setHoveredPoint(entry)}

--- a/app/globals.css
+++ b/app/globals.css
@@ -247,6 +247,7 @@
   --color-chart-label: theme(colors.gray.400);
   --color-chart-target-line: theme(colors.amber.500);
   --color-chart-point-fill: theme(colors.white);
+  --color-chart-line: theme(colors.blue.500);
 
   /* ===== 6. SPECIAL / PAGE-SPECIFIC ===== */
 
@@ -511,6 +512,7 @@
   --color-chart-label: theme(colors.gray.500);
   --color-chart-target-line: theme(colors.amber.400);
   --color-chart-point-fill: theme(colors.gray.700);
+  --color-chart-line: theme(colors.blue.400);
 
   /* ===== 6. SPECIAL / PAGE-SPECIFIC ===== */
 


### PR DESCRIPTION
## Summary
Refactored the ResourceHistoryChart component to use CSS custom properties instead of hardcoded color values, improving maintainability and enabling consistent theming across light and dark modes.

## Key Changes
- Replaced hardcoded hex color `#3b82f6` (blue-500) with `var(--color-chart-line)` CSS variable for chart lines
- Updated chart point fill color from hardcoded `#3b82f6` to `var(--color-chart-line)` for consistency
- Updated chart point stroke color from hardcoded `white` to `var(--color-chart-point-fill)` CSS variable
- Added `--color-chart-line` CSS variable definitions in globals.css:
  - Light mode: `theme(colors.blue.500)`
  - Dark mode: `theme(colors.blue.400)`

## Implementation Details
This change centralizes color management through CSS variables, allowing the chart styling to automatically adapt to theme changes without requiring component-level modifications. The new `--color-chart-line` variable follows the existing naming convention for chart-related CSS variables and includes appropriate color values for both light and dark themes.

https://claude.ai/code/session_01RtHZgtGMd4TbAGMjXjq8UX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated chart styling to use theme tokens, ensuring consistent colors across light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->