### PR TITLE
Add read-only tier column to resource CSV export

### DIFF
--- a/app/api/resources/bulk/route.ts
+++ b/app/api/resources/bulk/route.ts
@@ -200,16 +200,17 @@ export async function GET(request: NextRequest) {
     "quantityHagga",
     "quantityDeepDesert",
   ]);
-  if (
-    EXPORT_RESERVED.has(location1Name) ||
-    EXPORT_RESERVED.has(location2Name) ||
-    location1Name === location2Name
-  ) {
+  const conflictingNames = [location1Name, location2Name].filter((n) =>
+    EXPORT_RESERVED.has(n),
+  );
+  if (conflictingNames.length > 0 || location1Name === location2Name) {
+    const reserved = Array.from(EXPORT_RESERVED).join(", ");
+    const detail =
+      location1Name === location2Name
+        ? `location names must not be identical ("${location1Name}")`
+        : `"${conflictingNames.join('", "')}" conflicts with reserved column names (${reserved})`;
     return NextResponse.json(
-      {
-        error:
-          "Location names are misconfigured: they must not match reserved column names (id, name, tier, targetQuantity) or be identical to each other.",
-      },
+      { error: `Location names are misconfigured: ${detail}.` },
       { status: 500 },
     );
   }

--- a/app/api/resources/bulk/route.ts
+++ b/app/api/resources/bulk/route.ts
@@ -8,6 +8,7 @@ import Papa from "papaparse";
 import {
   UPDATE_THRESHOLD_NON_PRIORITY_MS,
   UPDATE_THRESHOLD_PRIORITY_MS,
+  TIER_OPTIONS,
 } from "@/lib/constants";
 import { getLocationNames } from "@/lib/global-settings";
 
@@ -49,12 +50,17 @@ function desanitizeCsvField(value: unknown): string {
   return value.length > 1 && value.startsWith("'") ? value.slice(1) : value;
 }
 
+function getTierLabel(tier: number | null | undefined): string {
+  if (tier === null || tier === undefined) return "";
+  return TIER_OPTIONS.find((t) => t.value === tier.toString())?.label ?? "";
+}
+
 /**
  * GET /api/resources/bulk
  *
  * Exports a filtered list of resources as a CSV file. The CSV contains
- * `id`, `name`, `quantityHagga`, `quantityDeepDesert`, and `targetQuantity`
- * columns. String fields are sanitized against CSV injection.
+ * `id`, `name`, `tier` (read-only label), the two location quantity columns,
+ * and `targetQuantity` columns. String fields are sanitized against CSV injection.
  *
  * Supports the same filter parameters as the main resource list:
  * `status`, `category`, `subcategory`, `tier`, `needsUpdate`, `priority`,
@@ -189,6 +195,7 @@ export async function GET(request: NextRequest) {
   const EXPORT_RESERVED = new Set([
     "id",
     "name",
+    "tier",
     "targetQuantity",
     "quantityHagga",
     "quantityDeepDesert",
@@ -201,7 +208,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       {
         error:
-          "Location names are misconfigured: they must not match reserved column names (id, name, targetQuantity) or be identical to each other.",
+          "Location names are misconfigured: they must not match reserved column names (id, name, tier, targetQuantity) or be identical to each other.",
       },
       { status: 500 },
     );
@@ -210,6 +217,7 @@ export async function GET(request: NextRequest) {
   const dataForCsv = filteredResources.map((r) => ({
     id: sanitizeCsvField(r.id),
     name: sanitizeCsvField(r.name),
+    tier: getTierLabel(r.tier),
     [location1Name]: r.quantityHagga,
     [location2Name]: r.quantityDeepDesert,
     targetQuantity: r.targetQuantity,

--- a/lib/changelog.json
+++ b/lib/changelog.json
@@ -14,6 +14,10 @@
         {
           "type": "improvement",
           "description": "Improved the Resource Details quantity-over-time chart with a proper coordinate system (viewBox), dashed grid lines, Y-axis labels, X-axis date labels, a dashed target line, path-based series rendering, and a legend below the chart."
+        },
+        {
+          "type": "improvement",
+          "description": "CSV export now includes a read-only 'tier' column showing the human-readable tier/grade label (e.g. \"Grade 4\", \"Tier 3 (Steel)\") to help identify resources that share the same name but differ by grade. The column is ignored on import."
         }
       ]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10726,6 +10726,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/tests/api/resources/bulk/route.test.ts
+++ b/tests/api/resources/bulk/route.test.ts
@@ -126,6 +126,74 @@ describe("GET /api/resources/bulk", () => {
 
     expect(mockWhere).toHaveBeenCalled();
   });
+
+  it("should include a read-only tier column with the human-readable label", async () => {
+    const mockWhere = jest.fn().mockResolvedValue([
+      {
+        id: "r1",
+        name: "Steel Plate",
+        tier: 3,
+        subcategory: null,
+        quantityHagga: 0,
+        quantityDeepDesert: 0,
+        targetQuantity: 10,
+      },
+      {
+        id: "r2",
+        name: "Burning Blades",
+        tier: 10,
+        subcategory: null,
+        quantityHagga: 0,
+        quantityDeepDesert: 0,
+        targetQuantity: 5,
+      },
+      {
+        id: "r3",
+        name: "No Tier",
+        tier: null,
+        subcategory: null,
+        quantityHagga: 0,
+        quantityDeepDesert: 0,
+        targetQuantity: 0,
+      },
+    ]);
+
+    jest.doMock("@/lib/db", () => ({
+      db: {
+        select: jest.fn().mockReturnValue({
+          from: jest.fn().mockReturnThis(),
+          where: mockWhere,
+        }),
+      },
+      resources: {
+        subcategory: "resources.subcategory",
+        tier: "resources.tier",
+        isPriority: "resources.isPriority",
+        updatedAt: "resources.updatedAt",
+      },
+    }));
+
+    jest.doMock("next-auth", () => ({
+      getServerSession: jest.fn().mockResolvedValue({
+        user: { roles: ["Target Editor"] },
+      }),
+    }));
+
+    jest.doMock("@/lib/discord-roles", () => ({
+      hasTargetEditAccess: jest.fn().mockReturnValue(true),
+    }));
+
+    const { GET } = await import("@/app/api/resources/bulk/route");
+    const request = new NextRequest("http://localhost/api/resources/bulk");
+    const response = await GET(request);
+    const csvText = await response.text();
+    const parsed = Papa.parse(csvText, { header: true });
+
+    expect(response.status).toBe(200);
+    expect((parsed.data[0] as any).tier).toBe("Tier 3 (Steel)");
+    expect((parsed.data[1] as any).tier).toBe("Grade 4");
+    expect((parsed.data[2] as any).tier).toBe("");
+  });
 });
 
 describe("POST /api/resources/bulk", () => {


### PR DESCRIPTION
## Summary
This PR adds a read-only `tier` column to the CSV export of resources, displaying human-readable tier/grade labels instead of numeric values. This helps users distinguish between resources that share the same name but differ by tier.

## Key Changes
- **New `getTierLabel()` function**: Converts numeric tier values to human-readable labels (e.g., "Grade 4", "Tier 3 (Steel)") using the existing `TIER_OPTIONS` constant
- **CSV export enhancement**: The `tier` column is now included in the exported data, positioned after the `name` column
- **Reserved column handling**: Added `tier` to the `EXPORT_RESERVED` set to prevent location names from conflicting with this column
- **Documentation updates**: Updated JSDoc and error messages to reflect the new `tier` column
- **Test coverage**: Added comprehensive test case validating tier label formatting for various tier values (including null/undefined cases)
- **Changelog entry**: Documented the improvement for users

## Implementation Details
- The tier label lookup uses `TIER_OPTIONS.find()` to match the numeric tier value and retrieve its label
- Null or undefined tier values are exported as empty strings
- The column is marked as read-only in the documentation, meaning it's ignored during CSV import
- The implementation reuses existing constants and follows the established pattern for CSV field sanitization

https://claude.ai/code/session_01L5fPnGSVeWUua5KNNbMqeR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV bulk export now includes a read-only `tier` column displaying the human-readable tier or grade label for each resource (e.g., "Grade 4", "Tier 3 (Steel)"). This column is automatically ignored during import to prevent configuration conflicts.

* **Tests**
  * Added test coverage for the new `tier` column functionality in CSV export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->