### PR TITLE
Add support for tier levels 7-11 with visual styling

### DIFF
--- a/app/components/ResourceTable.tsx
+++ b/app/components/ResourceTable.tsx
@@ -150,6 +150,29 @@ const getStatusTableColor = (status: string): string => {
   }
 };
 
+const getTierClassName = (tier: number): string => {
+  const tierClasses: { [key: number]: string } = {
+    0: "bg-tier-0-bg text-tier-0-text",
+    1: "bg-tier-1-bg text-tier-1-text",
+    2: "bg-tier-2-bg text-tier-2-text",
+    3: "bg-tier-3-bg text-tier-3-text",
+    4: "bg-tier-4-bg text-tier-4-text",
+    5: "bg-tier-5-bg text-tier-5-text",
+    6: "bg-tier-6-bg text-tier-6-text",
+    7: "bg-tier-7-bg text-tier-7-text",
+    8: "bg-tier-8-bg text-tier-8-text",
+    9: "bg-tier-9-bg text-tier-9-text",
+    10: "bg-tier-10-bg text-tier-10-text",
+    11: "bg-tier-11-bg text-tier-11-text",
+  };
+  return tierClasses[tier] ?? "bg-gray-200 text-gray-800";
+};
+
+const getTierShortLabel = (tier: number): string => {
+  if (tier <= 6) return `T${tier}`;
+  return `G${tier - 6}`;
+};
+
 interface Resource {
   id: string;
   name: string;
@@ -1821,6 +1844,14 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                               )}
                               {resource.name}
                             </h4>
+                            {resource.tier !== null &&
+                              resource.tier !== undefined && (
+                                <span
+                                  className={`inline-flex rounded-full px-2 py-0.5 text-xs font-semibold ${getTierClassName(resource.tier)}`}
+                                >
+                                  {getTierShortLabel(resource.tier)}
+                                </span>
+                              )}
 
                             {/* Status Badge */}
                             <div className="flex items-center justify-between">
@@ -2125,6 +2156,14 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                 />
                               </svg>
                             </div>
+                            {resource.tier !== null &&
+                              resource.tier !== undefined && (
+                                <span
+                                  className={`mt-1 inline-flex rounded-full px-2 py-0.5 text-xs font-semibold ${getTierClassName(resource.tier)}`}
+                                >
+                                  {getTierShortLabel(resource.tier)}
+                                </span>
+                              )}
                           </div>
                         </div>
                       </td>

--- a/app/globals.css
+++ b/app/globals.css
@@ -206,6 +206,16 @@
   --color-tier-5-text: theme(colors.amber.800);
   --color-tier-6-bg: theme(colors.blue.300);
   --color-tier-6-text: theme(colors.blue.800);
+  --color-tier-7-bg: theme(colors.violet.400);
+  --color-tier-7-text: theme(colors.violet.900);
+  --color-tier-8-bg: theme(colors.purple.400);
+  --color-tier-8-text: theme(colors.purple.900);
+  --color-tier-9-bg: theme(colors.fuchsia.400);
+  --color-tier-9-text: theme(colors.fuchsia.900);
+  --color-tier-10-bg: theme(colors.rose.400);
+  --color-tier-10-text: theme(colors.rose.900);
+  --color-tier-11-bg: theme(colors.red.400);
+  --color-tier-11-text: theme(colors.red.900);
 
   /* ===== 5. COMPONENTS ===== */
 
@@ -472,6 +482,16 @@
   --color-tier-5-text: theme(colors.amber.200);
   --color-tier-6-bg: theme(colors.blue.800);
   --color-tier-6-text: theme(colors.blue.200);
+  --color-tier-7-bg: theme(colors.violet.800);
+  --color-tier-7-text: theme(colors.violet.200);
+  --color-tier-8-bg: theme(colors.purple.800);
+  --color-tier-8-text: theme(colors.purple.200);
+  --color-tier-9-bg: theme(colors.fuchsia.800);
+  --color-tier-9-text: theme(colors.fuchsia.200);
+  --color-tier-10-bg: theme(colors.rose.800);
+  --color-tier-10-text: theme(colors.rose.200);
+  --color-tier-11-bg: theme(colors.red.800);
+  --color-tier-11-text: theme(colors.red.200);
 
   /* ===== 5. COMPONENTS ===== */
 

--- a/app/resources/[id]/page.tsx
+++ b/app/resources/[id]/page.tsx
@@ -43,8 +43,13 @@ const getTierClassName = (tier: number | null | undefined): string => {
     4: "bg-tier-4-bg text-tier-4-text",
     5: "bg-tier-5-bg text-tier-5-text",
     6: "bg-tier-6-bg text-tier-6-text",
+    7: "bg-tier-7-bg text-tier-7-text",
+    8: "bg-tier-8-bg text-tier-8-text",
+    9: "bg-tier-9-bg text-tier-9-text",
+    10: "bg-tier-10-bg text-tier-10-text",
+    11: "bg-tier-11-bg text-tier-11-text",
   };
-  return tierClasses[tier] || "bg-gray-200 text-gray-800";
+  return tierClasses[tier] ?? "bg-gray-200 text-gray-800";
 };
 
 const CHART_COLORS = {


### PR DESCRIPTION
## Summary
Extended the tier system to support 6 additional tier levels (7-11) beyond the existing 6 tiers. This includes adding visual styling for the new tiers and displaying tier badges on resources in the resource table.

## Key Changes
- **New tier levels**: Added support for tiers 7-11 with distinct color schemes (violet, purple, fuchsia, rose, and red)
- **Color definitions**: Added CSS custom properties for both light and dark modes in `globals.css` for all new tier levels
- **Tier display**: Added tier badge rendering in the ResourceTable component showing tier labels (T0-T6 for standard tiers, G1-G5 for gold tiers 7-11)
- **Helper functions**: 
  - `getTierClassName()`: Maps tier numbers to Tailwind CSS classes with background and text colors
  - `getTierShortLabel()`: Generates short labels for tiers (T-prefix for 0-6, G-prefix for 7-11)
- **Consistent styling**: Updated existing `getTierClassName()` in the resource detail page to support new tiers and use nullish coalescing operator

## Implementation Details
- Tier badges are displayed as inline-flex elements with rounded styling and appear in two locations within the resource table
- The tier display includes null/undefined checks to safely handle resources without tier assignments
- Color progression follows a logical visual hierarchy from standard tiers (gray→yellow→amber→blue) to gold tiers (violet→purple→fuchsia→rose→red)
- Both light and dark mode color variants are defined for accessibility

https://claude.ai/code/session_018j6736xUC5w7nr7E2N3Y14