### PR TITLE
Add /api/leaderboard and /api/global-settings to middleware matcher

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -60,5 +60,7 @@ export const config = {
     "/api/user/:path*",
     "/api/users/:path*",
     "/api/internal/:path*",
+    "/api/leaderboard/:path*",
+    "/api/global-settings",
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10726,6 +10726,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
Both routes had their own route-level auth checks but were missing from the
NextAuth middleware matcher, leaving them without the middleware safety net
that all other API routes have.

https://claude.ai/code/session_015QhUEWU2MHxDF3gspUdBFc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security by expanding authorization protection to additional API endpoints, including leaderboard and global settings functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->