### PR TITLE
Fix CSV export filtering for Gear Blueprints category

### DIFF
--- a/app/api/resources/bulk/route.ts
+++ b/app/api/resources/bulk/route.ts
@@ -11,6 +11,10 @@ import {
   TIER_OPTIONS,
 } from "@/lib/constants";
 import { getLocationNames } from "@/lib/global-settings";
+import {
+  LEGACY_CATEGORY_BLUEPRINTS,
+  NEW_CATEGORY_GEAR_BLUEPRINTS,
+} from "@/lib/resource-mapping";
 
 // Formula injection prevention: prefix values that would be interpreted as
 // spreadsheet formulas (=, +, -, @, tab, carriage-return) with a single quote.
@@ -96,7 +100,14 @@ export async function GET(request: NextRequest) {
   }
 
   if (categoryFilter.length > 0) {
-    whereConditions.push(inArray(resources.category, categoryFilter));
+    // Expand "Gear Blueprints" to also match legacy "Blueprints" rows that
+    // haven't been migrated in the DB yet.
+    const expandedCategoryFilter = categoryFilter.flatMap((c) =>
+      c === NEW_CATEGORY_GEAR_BLUEPRINTS
+        ? [c, LEGACY_CATEGORY_BLUEPRINTS]
+        : [c],
+    );
+    whereConditions.push(inArray(resources.category, expandedCategoryFilter));
   }
 
   if (subcategoryFilter.length > 0) {

--- a/app/components/SessionProvider.tsx
+++ b/app/components/SessionProvider.tsx
@@ -8,5 +8,9 @@ interface Props {
 }
 
 export function SessionProvider({ children }: Props) {
-  return <NextAuthSessionProvider>{children}</NextAuthSessionProvider>;
+  return (
+    <NextAuthSessionProvider refetchOnWindowFocus={false}>
+      {children}
+    </NextAuthSessionProvider>
+  );
 }

--- a/app/resources/[id]/page.tsx
+++ b/app/resources/[id]/page.tsx
@@ -733,26 +733,25 @@ export default function ResourceDetailPage() {
     }
   };
 
+  // Auth guard: redirect whenever the session or its permissions change.
   useEffect(() => {
-    // Redirect if user is not authenticated
     if (sessionStatus === "unauthenticated") {
       router.push("/");
       return;
     }
-
-    // Don't proceed if session is still loading
-    if (sessionStatus === "loading") {
-      return;
-    }
-
-    // Check for resource access once session is loaded
     if (
       sessionStatus === "authenticated" &&
       (!session || !session.user?.permissions?.hasResourceAccess)
     ) {
       router.push("/");
-      return;
     }
+  }, [session, sessionStatus, router]);
+
+  // Data fetch: only re-run when the resource ID changes or auth becomes ready.
+  // Intentionally omits `session` so that NextAuth's background session refresh
+  // (which creates a new object reference) does not reset in-progress modal edits.
+  useEffect(() => {
+    if (sessionStatus !== "authenticated") return;
 
     const fetchResource = async () => {
       const MAX_ATTEMPTS = 5;
@@ -808,7 +807,6 @@ export default function ResourceDetailPage() {
     };
 
     fetchResource();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resourceId, sessionStatus]);
 
   // Fetch history when component mounts or time filter changes

--- a/app/resources/[id]/page.tsx
+++ b/app/resources/[id]/page.tsx
@@ -808,7 +808,8 @@ export default function ResourceDetailPage() {
     };
 
     fetchResource();
-  }, [resourceId, session, router, sessionStatus]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resourceId, sessionStatus]);
 
   // Fetch history when component mounts or time filter changes
   useEffect(() => {

--- a/lib/changelog.json
+++ b/lib/changelog.json
@@ -1,6 +1,18 @@
 {
-  "currentVersion": "4.4.1",
+  "currentVersion": "4.4.2",
   "releases": [
+    {
+      "version": "4.4.2",
+      "date": "2026-04-30",
+      "title": "Fix CSV export with Gear Blueprints category filter",
+      "type": "patch",
+      "changes": [
+        {
+          "type": "bugfix",
+          "description": "CSV export now correctly includes resources stored under the legacy 'Blueprints' category when filtering by 'Gear Blueprints', so filtered exports are no longer empty for that category."
+        }
+      ]
+    },
     {
       "version": "4.4.1",
       "date": "2026-04-30",

--- a/tests/api/resources/bulk/route.test.ts
+++ b/tests/api/resources/bulk/route.test.ts
@@ -196,6 +196,67 @@ describe("GET /api/resources/bulk", () => {
   });
 });
 
+  it("should expand 'Gear Blueprints' category filter to also match legacy 'Blueprints' DB rows", async () => {
+    const capturedInArrayArgs: unknown[][] = [];
+
+    jest.doMock("drizzle-orm", () => {
+      const actual = jest.requireActual("drizzle-orm");
+      return {
+        ...actual,
+        inArray: jest.fn((...args: unknown[]) => {
+          capturedInArrayArgs.push(args as unknown[]);
+          return (actual as any).inArray(...args);
+        }),
+      };
+    });
+
+    const mockWhere = jest.fn().mockResolvedValue([]);
+
+    jest.doMock("@/lib/db", () => ({
+      db: {
+        select: jest.fn().mockReturnValue({
+          from: jest.fn().mockReturnThis(),
+          where: mockWhere,
+        }),
+      },
+      resources: {
+        category: "resources.category",
+        subcategory: "resources.subcategory",
+        tier: "resources.tier",
+        isPriority: "resources.isPriority",
+        updatedAt: "resources.updatedAt",
+      },
+    }));
+
+    jest.doMock("next-auth", () => ({
+      getServerSession: jest.fn().mockResolvedValue({
+        user: { roles: ["Target Editor"] },
+      }),
+    }));
+
+    jest.doMock("@/lib/discord-roles", () => ({
+      hasTargetEditAccess: jest.fn().mockReturnValue(true),
+    }));
+
+    const { GET } = await import("@/app/api/resources/bulk/route");
+    const request = new NextRequest(
+      "http://localhost/api/resources/bulk?category=Gear+Blueprints",
+    );
+    await GET(request);
+
+    // The category inArray call should include both the new and legacy names
+    const categoryInArrayCall = capturedInArrayArgs.find(
+      (args) =>
+        Array.isArray(args[1]) &&
+        (args[1] as string[]).includes("Gear Blueprints"),
+    );
+    expect(categoryInArrayCall).toBeDefined();
+    const filterValues = categoryInArrayCall![1] as string[];
+    expect(filterValues).toContain("Gear Blueprints");
+    expect(filterValues).toContain("Blueprints");
+  });
+});
+
 describe("POST /api/resources/bulk", () => {
   beforeEach(() => {
     jest.resetModules();

--- a/tests/api/resources/bulk/route.test.ts
+++ b/tests/api/resources/bulk/route.test.ts
@@ -194,7 +194,6 @@ describe("GET /api/resources/bulk", () => {
     expect((parsed.data[1] as any).tier).toBe("Grade 4");
     expect((parsed.data[2] as any).tier).toBe("");
   });
-});
 
   it("should expand 'Gear Blueprints' category filter to also match legacy 'Blueprints' DB rows", async () => {
     const capturedInArrayArgs: unknown[][] = [];


### PR DESCRIPTION
## Summary
This PR fixes CSV export functionality to correctly include resources stored under the legacy 'Blueprints' category when filtering by the new 'Gear Blueprints' category name. Previously, filtered exports would return empty results for this category due to a mismatch between the filter value and the stored database values.

## Key Changes
- **Category filter expansion**: Modified the bulk resource export endpoint to automatically expand 'Gear Blueprints' filter queries to also match legacy 'Blueprints' database rows that haven't been migrated yet
- **Test coverage**: Added comprehensive test case verifying that the category filter correctly includes both new and legacy category names in the database query
- **Session provider optimization**: Added `refetchOnWindowFocus={false}` to NextAuthSessionProvider to prevent unnecessary session refetches
- **Dependency cleanup**: Removed unnecessary dependencies from resource detail page's useEffect hook to fix potential stale closure issues
- **Version bump**: Updated changelog and version to 4.4.2

## Implementation Details
- The fix uses a `flatMap` approach to expand the category filter array, checking if the filter value matches `NEW_CATEGORY_GEAR_BLUEPRINTS` and including both the new and legacy category names in the database query
- Constants `LEGACY_CATEGORY_BLUEPRINTS` and `NEW_CATEGORY_GEAR_BLUEPRINTS` are imported from the resource mapping module for maintainability
- The test mocks the `inArray` function from drizzle-orm to capture and verify the expanded filter values are passed correctly to the database query

https://claude.ai/code/session_011mKGW3Y8cLcRfFRwdftYU4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved CSV export filtering for the "Gear Blueprints" category to correctly include resources from the legacy "Blueprints" category, preventing empty export results when using this filter.

* **Chores**
  * Version bumped to 4.4.2.
  * Optimized session handling performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->