### PR TITLE
feat: replace synthetic sparklines with real 30-day historical data

### DIFF
--- a/app/api/internal/resources/sparklines/route.ts
+++ b/app/api/internal/resources/sparklines/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { db, resourceHistory } from "@/lib/db";
+import { gte, desc } from "drizzle-orm";
+import { hasResourceAccess } from "@/lib/discord-roles";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/internal/resources/sparklines?days=30
+ *
+ * Returns daily quantity totals for all resources over the last `days` days
+ * (default: 30). For resources with fewer than 2 data points in that window,
+ * falls back to their all-time history.
+ *
+ * Response shape: `{ [resourceId]: number[] }` — oldest-first daily totals.
+ */
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || !hasResourceAccess(session.user.roles)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const days = Math.max(
+      1,
+      Math.min(500, parseInt(searchParams.get("days") || "30", 10) || 30),
+    );
+
+    const daysAgo = new Date();
+    daysAgo.setDate(daysAgo.getDate() - days);
+
+    const recentRows = await db
+      .select({
+        resourceId: resourceHistory.resourceId,
+        newQuantityHagga: resourceHistory.newQuantityHagga,
+        newQuantityDeepDesert: resourceHistory.newQuantityDeepDesert,
+        newQuantityLocation1: resourceHistory.newQuantityLocation1,
+        newQuantityLocation2: resourceHistory.newQuantityLocation2,
+        createdAt: resourceHistory.createdAt,
+      })
+      .from(resourceHistory)
+      .where(gte(resourceHistory.createdAt, daysAgo))
+      .orderBy(desc(resourceHistory.createdAt));
+
+    // Group rows by resourceId → day → last entry per day
+    const byResource: Record<
+      string,
+      { day: string; total: number }[]
+    > = {};
+
+    for (const row of recentRows) {
+      const qty1 = row.newQuantityLocation1 ?? row.newQuantityHagga;
+      const qty2 = row.newQuantityLocation2 ?? row.newQuantityDeepDesert;
+      const total = qty1 + qty2;
+      const day = new Date(row.createdAt).toISOString().slice(0, 10);
+      const rid = row.resourceId;
+
+      if (!byResource[rid]) byResource[rid] = [];
+      // Since rows are ordered desc, the first time we see a day is the latest entry for it
+      if (!byResource[rid].some((e) => e.day === day)) {
+        byResource[rid].push({ day, total });
+      }
+    }
+
+    // Build result: oldest-first arrays. Collect resourceIds with < 2 points.
+    const result: Record<string, number[]> = {};
+    const needsFallback: string[] = [];
+
+    for (const [rid, entries] of Object.entries(byResource)) {
+      if (entries.length < 2) {
+        needsFallback.push(rid);
+      } else {
+        result[rid] = entries
+          .slice()
+          .sort((a, b) => a.day.localeCompare(b.day))
+          .map((e) => e.total);
+      }
+    }
+
+    // All-time fallback for resources with insufficient recent data
+    if (needsFallback.length > 0) {
+      const allTimeRows = await db
+        .select({
+          resourceId: resourceHistory.resourceId,
+          newQuantityHagga: resourceHistory.newQuantityHagga,
+          newQuantityDeepDesert: resourceHistory.newQuantityDeepDesert,
+          newQuantityLocation1: resourceHistory.newQuantityLocation1,
+          newQuantityLocation2: resourceHistory.newQuantityLocation2,
+          createdAt: resourceHistory.createdAt,
+        })
+        .from(resourceHistory)
+        .orderBy(desc(resourceHistory.createdAt));
+
+      const allTimeByResource: Record<
+        string,
+        { day: string; total: number }[]
+      > = {};
+
+      for (const row of allTimeRows) {
+        const rid = row.resourceId;
+        if (!needsFallback.includes(rid)) continue;
+        const qty1 = row.newQuantityLocation1 ?? row.newQuantityHagga;
+        const qty2 = row.newQuantityLocation2 ?? row.newQuantityDeepDesert;
+        const total = qty1 + qty2;
+        const day = new Date(row.createdAt).toISOString().slice(0, 10);
+
+        if (!allTimeByResource[rid]) allTimeByResource[rid] = [];
+        if (!allTimeByResource[rid].some((e) => e.day === day)) {
+          allTimeByResource[rid].push({ day, total });
+        }
+      }
+
+      for (const rid of needsFallback) {
+        const entries = allTimeByResource[rid];
+        if (entries && entries.length >= 2) {
+          result[rid] = entries
+            .slice()
+            .sort((a, b) => a.day.localeCompare(b.day))
+            .map((e) => e.total);
+        }
+        // Resources with < 2 all-time entries are omitted (no sparkline shown)
+      }
+    }
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error fetching sparklines:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch sparklines" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/resources/sparklines/route.ts
+++ b/app/api/resources/sparklines/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { hasResourceAccess } from "@/lib/discord-roles";
+
+/**
+ * GET /api/resources/sparklines?days=30
+ *
+ * Authenticated proxy to the internal sparklines endpoint.
+ * Returns `{ [resourceId]: number[] }` — oldest-first daily quantity totals.
+ * Resources with fewer than 2 data points in the window fall back to all-time.
+ *
+ * Requires resource access.
+ */
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user || !hasResourceAccess(session.user.roles)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+
+  const internalUrl = new URL(
+    `/api/internal/resources/sparklines?${searchParams.toString()}`,
+    request.nextUrl.origin,
+  );
+
+  try {
+    const response = await fetch(internalUrl, {
+      next: { revalidate: 60 },
+      headers: {
+        cookie: request.headers.get("cookie") || "",
+        authorization: request.headers.get("authorization") || "",
+      },
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      console.error(
+        `Internal sparklines call failed with status ${response.status}:`,
+        errorBody,
+      );
+      return new NextResponse(errorBody, {
+        status: response.status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const data = await response.json();
+    return new NextResponse(JSON.stringify(data), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("Error fetching from internal sparklines route:", error);
+    return new NextResponse(
+      JSON.stringify({ error: "Failed to fetch sparklines" }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+}

--- a/app/components/ResourceTable.tsx
+++ b/app/components/ResourceTable.tsx
@@ -202,21 +202,16 @@ const getProgressBarColorStyle = (status: string): React.CSSProperties => ({
 const getSparklineColor = (status: string): string =>
   STATUS_COLOR_MAP[status] ?? "var(--color-border-secondary)";
 
-// Generates a deterministic sparkline SVG element based on resource id
+// Renders a sparkline SVG from an array of quantity data points
 function renderSparklineSVG(
-  id: string,
+  dataPoints: number[],
   status: string,
   w = 68,
   h = 28,
-): React.ReactElement {
-  const seed = id.split("").reduce((a, c) => a + c.charCodeAt(0), 0);
-  const pts: number[] = [];
-  let v = 0.4 + ((seed * 9301 + 49297) % 233280) / 466560 * 0.4;
-  for (let i = 0; i < 10; i++) {
-    const n = ((seed * (i + 7) * 2654435761) % 1000) / 1000 - 0.5;
-    v = Math.max(0.05, Math.min(0.95, v + n * 0.22));
-    pts.push(v);
-  }
+): React.ReactElement | null {
+  if (!dataPoints || dataPoints.length < 2) return null;
+
+  const pts = dataPoints;
   const pad = 2;
   const min = Math.min(...pts);
   const max = Math.max(...pts);
@@ -411,6 +406,11 @@ export function ResourceTable({ userId }: ResourceTableProps) {
     resource: Resource | null;
   }>({ isOpen: false, resource: null });
 
+  // Sparkline data: resourceId → daily quantity totals (oldest-first)
+  const [sparklineData, setSparklineData] = useState<Record<string, number[]>>(
+    {},
+  );
+
   // Load view preference
   useEffect(() => {
     const savedViewMode = localStorage.getItem(LOCAL_STORAGE_KEYS.VIEW_MODE);
@@ -418,6 +418,15 @@ export function ResourceTable({ userId }: ResourceTableProps) {
       setViewMode(savedViewMode as (typeof VIEW_MODE)[keyof typeof VIEW_MODE]);
     }
   }, []);
+
+  // Fetch sparkline data when in grid mode
+  useEffect(() => {
+    if (viewMode !== VIEW_MODE.GRID) return;
+    fetch("/api/resources/sparklines?days=30")
+      .then((res) => (res.ok ? res.json() : {}))
+      .then((data: Record<string, number[]>) => setSparklineData(data))
+      .catch(() => {});
+  }, [viewMode]);
 
   // Save view preference
   const setAndSaveViewMode = (
@@ -1970,7 +1979,10 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                 {formatNumber(resource.quantityDeepDesert)}
                               </div>
                             </div>
-                            {renderSparklineSVG(resource.id, status)}
+                            {renderSparklineSVG(
+                              sparklineData[resource.id] ?? [],
+                              status,
+                            )}
                           </div>
 
                           {/* Progress bar */}

--- a/lib/changelog.json
+++ b/lib/changelog.json
@@ -18,6 +18,10 @@
         {
           "type": "improvement",
           "description": "Resource details page image container is now larger (160×160 px), rounded, with a tier pill overlaid on the corner."
+        },
+        {
+          "type": "improvement",
+          "description": "Sparkline charts on resource grid cards now display real 30-day historical data fetched via a batch endpoint, with an all-time fallback for resources that have fewer than 2 data points in the window. Resources with no history show no sparkline."
         }
       ]
     },

--- a/tests/components/ResourceTable.test.tsx
+++ b/tests/components/ResourceTable.test.tsx
@@ -116,6 +116,12 @@ describe("ResourceTable", () => {
 
     // Mock fetch
     global.fetch = jest.fn((url) => {
+      if (url.toString().includes("/api/resources/sparklines")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({}),
+        });
+      }
       if (url.toString().startsWith(RESOURCES_API_PATH)) {
         return Promise.resolve({
           ok: true,


### PR DESCRIPTION
Adds GET /api/resources/sparklines batch endpoint that queries all resource history for the last 30 days and returns oldest-first daily quantity totals per resource. Resources with fewer than 2 data points in the window fall back to all-time history; resources with no history are omitted so the card renders no sparkline instead of fake data.
