### PR TITLE
Add synthetic sparkline placeholders for resources without history

### DIFF
--- a/app/components/ResourceTable.tsx
+++ b/app/components/ResourceTable.tsx
@@ -202,7 +202,37 @@ const getProgressBarColorStyle = (status: string): React.CSSProperties => ({
 const getSparklineColor = (status: string): string =>
   STATUS_COLOR_MAP[status] ?? "var(--color-border-secondary)";
 
-// Renders a sparkline SVG from an array of quantity data points
+// FNV-1a + xorshift32 seeded PRNG derived from a string seed
+function seededRandom(seed: string): () => number {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  let state = h || 1;
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state = state >>> 0;
+    return state / 4294967296;
+  };
+}
+
+// Generate deterministic synthetic quantity history from a resource ID
+function generateSyntheticDataPoints(id: string, count = 20): number[] {
+  const rng = seededRandom(id);
+  const base = 40 + rng() * 160;
+  const points: number[] = [base];
+  for (let i = 1; i < count; i++) {
+    const delta = (rng() - 0.42) * 30;
+    points.push(Math.max(1, points[i - 1] + delta));
+  }
+  return points;
+}
+
+// Renders a sparkline SVG from an array of quantity data points.
+// The SVG uses width="100%" so it fills whatever container it's placed in.
 function renderSparklineSVG(
   dataPoints: number[],
   status: string,
@@ -228,10 +258,11 @@ function renderSparklineSVG(
   const stroke = getSparklineColor(status);
   return (
     <svg
-      width={w}
+      width="100%"
       height={h}
       viewBox={`0 0 ${w} ${h}`}
-      style={{ display: "block", overflow: "visible", flexShrink: 0 }}
+      preserveAspectRatio="none"
+      style={{ display: "block", overflow: "visible" }}
     >
       <path d={area} fill={stroke} opacity={0.15} />
       <path
@@ -244,6 +275,40 @@ function renderSparklineSVG(
       />
       <circle cx={last.x} cy={last.y} r={2} fill={stroke} />
     </svg>
+  );
+}
+
+// Renders a blurred synthetic sparkline with a "NOT ENOUGH HISTORICAL DATA"
+// overlay for resources that have no real history to display.
+function renderSyntheticSparklinePlaceholder(
+  id: string,
+  status: string,
+): React.ReactElement {
+  const syntheticPoints = generateSyntheticDataPoints(id);
+  return (
+    <div
+      className="relative"
+      data-testid="sparkline-placeholder"
+      style={{ userSelect: "none" }}
+    >
+      <div style={{ filter: "blur(2.5px)", opacity: 0.4 }}>
+        {renderSparklineSVG(syntheticPoints, status)}
+      </div>
+      <div className="absolute inset-0 flex items-center justify-center">
+        <span
+          className="text-center leading-tight text-text-quaternary"
+          style={{
+            fontSize: "6px",
+            fontVariant: "small-caps",
+            letterSpacing: "0.05em",
+          }}
+        >
+          NOT ENOUGH
+          <br />
+          HISTORICAL DATA
+        </span>
+      </div>
+    </div>
   );
 }
 
@@ -1979,10 +2044,18 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                                 {formatNumber(resource.quantityDeepDesert)}
                               </div>
                             </div>
-                            {renderSparklineSVG(
-                              sparklineData[resource.id] ?? [],
-                              status,
-                            )}
+                            {/* Responsive sparkline container: wider on full-width single-column cards */}
+                            <div className="w-28 flex-shrink-0 sm:w-20 lg:w-[68px]">
+                              {sparklineData[resource.id]
+                                ? renderSparklineSVG(
+                                    sparklineData[resource.id],
+                                    status,
+                                  )
+                                : renderSyntheticSparklinePlaceholder(
+                                    resource.id,
+                                    status,
+                                  )}
+                            </div>
                           </div>
 
                           {/* Progress bar */}

--- a/app/components/ResourceTable.tsx
+++ b/app/components/ResourceTable.tsx
@@ -2046,7 +2046,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                             </div>
                             {/* Responsive sparkline container: wider on full-width single-column cards */}
                             <div className="w-28 flex-shrink-0 sm:w-20 lg:w-[68px]">
-                              {sparklineData[resource.id]
+                              {sparklineData[resource.id]?.length >= 2
                                 ? renderSparklineSVG(
                                     sparklineData[resource.id],
                                     status,

--- a/lib/changelog.json
+++ b/lib/changelog.json
@@ -22,6 +22,10 @@
         {
           "type": "improvement",
           "description": "Sparkline charts on resource grid cards now display real 30-day historical data fetched via a batch endpoint, with an all-time fallback for resources that have fewer than 2 data points in the window. Resources with no history show no sparkline."
+        },
+        {
+          "type": "improvement",
+          "description": "Resource grid cards now always show a sparkline: resources with insufficient history display a deterministic pseudo-random synthetic curve (seeded from the resource ID) behind a blur and a small-caps 'NOT ENOUGH HISTORICAL DATA' overlay, keeping card layouts consistent. The sparkline is also responsive — wider on single-column (full-width) cards and narrower in multi-column grid layouts."
         }
       ]
     },

--- a/lib/changelog.json
+++ b/lib/changelog.json
@@ -21,7 +21,7 @@
         },
         {
           "type": "improvement",
-          "description": "Sparkline charts on resource grid cards now display real 30-day historical data fetched via a batch endpoint, with an all-time fallback for resources that have fewer than 2 data points in the window. Resources with no history show no sparkline."
+          "description": "Sparkline charts on resource grid cards now display real 30-day historical data fetched via a batch endpoint, with an all-time fallback for resources that have fewer than 2 data points in the window."
         },
         {
           "type": "improvement",

--- a/tests/components/ResourceTable.test.tsx
+++ b/tests/components/ResourceTable.test.tsx
@@ -282,6 +282,59 @@ describe("ResourceTable", () => {
     });
   });
 
+  it("shows synthetic sparkline placeholders when resources have no history", async () => {
+    render(<ResourceTable userId="test-user" />);
+    await screen.findByText("Recent Updates");
+
+    // Sparklines API returns {} so all resources lack history; each card should
+    // render a synthetic placeholder with the data-testid marker.
+    await waitFor(() => {
+      const placeholders = screen.getAllByTestId("sparkline-placeholder");
+      expect(placeholders.length).toBe(mockResources.length);
+    });
+  });
+
+  it("replaces synthetic placeholder with real sparkline when history is available", async () => {
+    // Return sparkline data for resource id "1" (Iron Ore) only
+    global.fetch = jest.fn((url) => {
+      if (url.toString().includes("/api/resources/sparklines")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ "1": [10, 20, 30, 40, 50] }),
+        });
+      }
+      if (url.toString().startsWith(RESOURCES_API_PATH)) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockResources),
+        });
+      }
+      if (url.toString().startsWith(USER_ACTIVITY_API_PATH)) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockActivity),
+        });
+      }
+      if (url.toString().startsWith(LEADERBOARD_API_PATH)) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockLeaderboard),
+        });
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+    }) as jest.Mock;
+
+    render(<ResourceTable userId="test-user" />);
+    await screen.findByText("Recent Updates");
+
+    // Resource "1" has data → real sparkline (no placeholder).
+    // The other 3 resources still show placeholders.
+    await waitFor(() => {
+      const placeholders = screen.getAllByTestId("sparkline-placeholder");
+      expect(placeholders).toHaveLength(mockResources.length - 1);
+    });
+  });
+
   it("switches between grid and table view", async () => {
     render(<ResourceTable userId="test-user" />);
     await screen.findByText("Recent Updates");


### PR DESCRIPTION
## Summary
Resources without sufficient historical data now display a deterministic synthetic sparkline placeholder instead of being blank. This keeps card layouts consistent while clearly indicating that real data is unavailable.

## Key Changes
- **Seeded PRNG**: Added `seededRandom()` function using FNV-1a hashing + xorshift32 to generate deterministic pseudo-random numbers from a resource ID string
- **Synthetic data generation**: Implemented `generateSyntheticDataPoints()` to create a 20-point synthetic quantity curve seeded from the resource ID, ensuring the same resource always shows the same curve
- **Placeholder component**: Created `renderSyntheticSparklinePlaceholder()` that displays a blurred synthetic sparkline with a small-caps "NOT ENOUGH HISTORICAL DATA" overlay
- **Responsive sparkline container**: Wrapped sparkline rendering in a responsive div with breakpoint-specific widths (w-28 on mobile, sm:w-20 on tablets, lg:w-[68px] on desktop)
- **Conditional rendering**: Updated the sparkline display logic to show real sparklines when available, otherwise render the synthetic placeholder
- **SVG improvements**: Changed sparkline SVG width from fixed pixel value to `width="100%"` with `preserveAspectRatio="none"` for better responsive scaling, and removed `flexShrink: 0` to allow proper container sizing

## Testing
Added two new test cases:
- Verifies synthetic placeholders render when no sparkline history is available
- Confirms real sparklines replace placeholders when history data becomes available

https://claude.ai/code/session_011vUhJUqVsWVUB9EP7ACT2P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource grid now always displays sparkline charts with improved responsiveness
  * Resources lacking sufficient historical data show a placeholder with "NOT ENOUGH HISTORICAL DATA" messaging instead of empty space

<!-- end of auto-generated comment: release notes by coderabbit.ai -->