### PR TITLE
Remove Refined special-casing; all categories now earn leaderboard points

### DIFF
--- a/app/dashboard/contributions/[userId]/page.tsx
+++ b/app/dashboard/contributions/[userId]/page.tsx
@@ -398,10 +398,6 @@ export default function UserContributionsPage() {
               quantity
             </p>
             <p>
-              <strong>Refined Actions:</strong> Fixed 2 points for any action
-              (special category)
-            </p>
-            <p>
               <strong>Multipliers:</strong> Resources have different point
               multipliers (0.1x to 5x+)
             </p>
@@ -410,8 +406,7 @@ export default function UserContributionsPage() {
               Target +5%
             </p>
             <p>
-              <strong>Categories:</strong> Raw, Components, and Refined
-              categories earn points
+              <strong>Categories:</strong> All resource categories earn points
             </p>
           </div>
         </div>

--- a/app/dashboard/leaderboard/page.tsx
+++ b/app/dashboard/leaderboard/page.tsx
@@ -290,10 +290,6 @@ export default function LeaderboardPage() {
               quantity
             </p>
             <p>
-              <strong>Refined Actions:</strong> Fixed 2 points for any action
-              (special category)
-            </p>
-            <p>
               <strong>Multipliers:</strong> Resources have different point
               multipliers (0.1x to 5x+)
             </p>
@@ -302,8 +298,7 @@ export default function LeaderboardPage() {
               Target +5%
             </p>
             <p>
-              <strong>Categories:</strong> Raw, Components, and Refined
-              categories earn points
+              <strong>Categories:</strong> All resource categories earn points
             </p>
           </div>
         </div>

--- a/lib/changelog.json
+++ b/lib/changelog.json
@@ -22,6 +22,10 @@
       {
         "type": "improvement",
         "description": "The image container on the Resource Details page has been enlarged to 160×160 px, rounded, and updated to include the overlaid tier pill."
+      },
+      {
+        "type": "improvement",
+        "description": "All resource categories now earn leaderboard points for ADD and SET actions. The Refined category no longer receives a fixed 2-point bonus — it uses the same quantity/multiplier/status-bonus formula as all other categories."
       }
       ]
     },

--- a/lib/leaderboard.ts
+++ b/lib/leaderboard.ts
@@ -6,7 +6,6 @@ import { mapCategoryForRead } from "./resource-mapping";
 // Constants for points calculation
 const BASE_POINTS_PER_1000_RESOURCES = 100;
 const SET_ACTION_POINTS = 1;
-const REFINED_ACTION_POINTS = 2; // Special points for Refined category
 
 // Status bonuses (as decimal percentages).
 // calculateResourceStatus returns only: "critical", "below_target", "at_target", "above_target".
@@ -21,9 +20,6 @@ const STATUS_BONUSES = {
   well_stocked: 0.0, // 0% — reserved, not currently returned by calculateResourceStatus
   surplus: 0.0, // 0% — reserved, not currently returned by calculateResourceStatus
 };
-
-// Categories that are eligible for points (Raw, Components, and Refined)
-const ELIGIBLE_CATEGORIES = ["Raw", "Components", "Refined"];
 
 export interface PointsCalculation {
   basePoints: number;
@@ -42,26 +38,13 @@ export function calculatePoints(
   resourceStatus: string,
   resourceCategory: string,
 ): PointsCalculation {
-  // No points for REMOVE actions or ineligible categories
-  if (
-    actionType === "REMOVE" ||
-    !ELIGIBLE_CATEGORIES.includes(resourceCategory)
-  ) {
+  // No points for REMOVE actions
+  if (actionType === "REMOVE") {
     return {
       basePoints: 0,
       resourceMultiplier,
       statusBonus: 0,
       finalPoints: 0,
-    };
-  }
-
-  // Special handling for Refined category - always 100 points flat
-  if (resourceCategory === "Refined") {
-    return {
-      basePoints: REFINED_ACTION_POINTS,
-      resourceMultiplier: 0, // Show as 0x for refined
-      statusBonus: 0,
-      finalPoints: REFINED_ACTION_POINTS,
     };
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10510,6 +10510,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/tests/lib/leaderboard.test.ts
+++ b/tests/lib/leaderboard.test.ts
@@ -60,16 +60,16 @@ describe("calculatePoints", () => {
     expect(result.finalPoints).toBe(10000);
   });
 
-  it("should return fixed 2 points for Refined category regardless of status or multiplier", () => {
-    const critical = calculatePoints("ADD", 5000, 3, "critical", "Refined");
-    expect(critical.finalPoints).toBe(2);
-    const at = calculatePoints("ADD", 5000, 3, "at_target", "Refined");
-    expect(at.finalPoints).toBe(2);
+  it("should calculate Refined ADD actions using the standard formula", () => {
+    // base=500, ×3 mult=1500, ×1.1 critical bonus=1650
+    const result = calculatePoints("ADD", 5000, 3, "critical", "Refined");
+    expect(result.finalPoints).toBe(1650);
   });
 
-  it("should return 0 points for ineligible category", () => {
-    const result = calculatePoints("ADD", 5000, 2, "critical", "Blueprints");
-    expect(result.finalPoints).toBe(0);
+  it("should calculate points for previously-ineligible categories (e.g. Gear Blueprints)", () => {
+    // base=500, ×2 mult=1000, ×1.1 critical bonus=1100
+    const result = calculatePoints("ADD", 5000, 2, "critical", "Gear Blueprints");
+    expect(result.finalPoints).toBe(1100);
   });
 });
 
@@ -103,15 +103,15 @@ describe("awardPoints", () => {
     expect(mockDb.values).toHaveBeenCalled();
   });
 
-  it("should not create a leaderboard entry for the legacy 'Blueprints' category", async () => {
+  it("should create a leaderboard entry for the legacy 'Blueprints' category (now earns points)", async () => {
     const mockDb = {
       insert: jest.fn().mockReturnThis(),
       values: jest.fn().mockResolvedValue(undefined),
     };
 
     const { awardPoints } = await import("@/lib/leaderboard");
-    // Legacy "Blueprints" maps to "Gear Blueprints" which is an ineligible
-    // category, so no leaderboard entry should be created.
+    // Legacy "Blueprints" maps to "Gear Blueprints". All categories now earn points,
+    // so a leaderboard entry should be created.
     const result = await awardPoints(
       "test-user",
       "test-resource",
@@ -126,8 +126,9 @@ describe("awardPoints", () => {
       mockDb,
     );
 
-    expect(result.finalPoints).toBe(0);
-    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(result.finalPoints).toBeGreaterThan(0);
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(mockDb.values).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
- Drop REFINED_ACTION_POINTS constant and Refined fixed-2-point branch from
  calculatePoints — Refined ADD actions now use the same qty/multiplier/
  status-bonus formula as Raw and Components
- Drop ELIGIBLE_CATEGORIES and the ineligibility guard, so all resource
  categories (Gear, Gear Blueprints, Augmentations, etc.) earn points
- Update leaderboard and contributions "How Points Work" UI copy to remove
  the "Refined Actions" special-category note and say all categories earn points
- Update tests: replace Refined fixed-points test with standard-formula test,
  flip the legacy-Blueprints awardPoints test (now earns points), add
  Gear Blueprints earns-points test

https://claude.ai/code/session_0175XiM4AYrRu39G92P4UbYH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * All resource categories now earn leaderboard points using a unified calculation method, replacing the previous category-specific rules.
  * Refined category no longer receives a fixed 2-point bonus and now follows the standard point formula.

* **Documentation**
  * Updated "How Points Work" sections across dashboard pages to reflect the simplified point system.

* **Tests**
  * Updated test coverage to reflect new point calculation behavior across all resource categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->