### PR TITLE
Add error logging for Discord guild member fetch failures

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -226,6 +226,16 @@ export const authOptions: NextAuthOptions = {
               }
             }
           } else {
+            const body = await response.text().catch(() => "<unreadable>");
+            console.error(
+              "Discord guild member fetch failed:",
+              response.status,
+              response.statusText,
+              "guildId=",
+              guildId,
+              "body=",
+              body,
+            );
             token.userRoles = [];
             token.isInGuild = false;
             token.discordNickname = null;


### PR DESCRIPTION
## Summary
Added detailed error logging when the Discord guild member fetch request fails, improving debuggability of authentication issues.

## Key Changes
- Added error logging that captures the HTTP response status, status text, guild ID, and response body when the Discord guild member fetch fails
- Implemented safe body reading with a fallback to `"<unreadable>"` if the response body cannot be parsed
- Logs are output to console.error for visibility in server logs

## Implementation Details
The error logging is placed in the else block that handles failed guild member fetch responses, providing context about what went wrong without changing the existing error handling behavior (still sets `userRoles` to empty array, `isInGuild` to false, and `discordNickname` to null).

https://claude.ai/code/session_01PZVR4SUkgXyiuX7YMLV2uQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging in Discord authentication flow to provide more detailed diagnostic information when member data retrieval fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->