### PR TITLE
Store Discord IDs in history; resolve display names at read time

### DIFF
--- a/app/api/internal/cleanup/route.ts
+++ b/app/api/internal/cleanup/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { db, resourceHistory } from "@/lib/db";
+import { lt } from "drizzle-orm";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/internal/cleanup
+ *
+ * Deletes resource_history entries older than 6 months on a rolling basis.
+ * The 6-month window is generous given that history charts only go back 3
+ * months and the resource table always holds current state.
+ *
+ * Intended to be invoked by a Vercel Cron job. Not authenticated — only
+ * callable internally via the cron scheduler (protected by Vercel's
+ * infrastructure, not user-facing).
+ */
+export async function GET() {
+  try {
+    const cutoff = new Date();
+    cutoff.setMonth(cutoff.getMonth() - 6);
+
+    const result = await db
+      .delete(resourceHistory)
+      .where(lt(resourceHistory.createdAt, cutoff));
+
+    const rowsDeleted =
+      (result as unknown as { rowsAffected?: number }).rowsAffected ?? 0;
+
+    console.log(
+      `[cleanup] Deleted ${rowsDeleted} resource_history entries older than ${cutoff.toISOString()}`,
+    );
+
+    return NextResponse.json({
+      deleted: rowsDeleted,
+      cutoff: cutoff.toISOString(),
+    });
+  } catch (error) {
+    console.error("[cleanup] Failed to prune resource history:", error);
+    return NextResponse.json(
+      { error: "Cleanup failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/internal/cleanup/route.ts
+++ b/app/api/internal/cleanup/route.ts
@@ -30,7 +30,9 @@ export async function GET(request: NextRequest) {
     // current day doesn't exist in the target month (e.g. Aug 31 → March 2).
     const cutoff = new Date(Date.now() - 6 * 30 * 24 * 60 * 60 * 1000);
 
-    await db.delete(resourceHistory).where(lt(resourceHistory.createdAt, cutoff));
+    await db
+      .delete(resourceHistory)
+      .where(lt(resourceHistory.createdAt, cutoff));
 
     console.log(
       `[cleanup] Pruned resource_history entries older than ${cutoff.toISOString()}`,
@@ -39,9 +41,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ cutoff: cutoff.toISOString() });
   } catch (error) {
     console.error("[cleanup] Failed to prune resource history:", error);
-    return NextResponse.json(
-      { error: "Cleanup failed" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Cleanup failed" }, { status: 500 });
   }
 }

--- a/app/api/internal/cleanup/route.ts
+++ b/app/api/internal/cleanup/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { db, resourceHistory } from "@/lib/db";
 import { lt } from "drizzle-orm";
 
@@ -11,30 +11,31 @@ export const dynamic = "force-dynamic";
  * The 6-month window is generous given that history charts only go back 3
  * months and the resource table always holds current state.
  *
- * Intended to be invoked by a Vercel Cron job. Not authenticated — only
- * callable internally via the cron scheduler (protected by Vercel's
- * infrastructure, not user-facing).
+ * Secured via `CRON_SECRET` as recommended by Vercel for cron routes:
+ * https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs
+ *
+ * Intended to be invoked by the Vercel Cron scheduler only.
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (
+    !cronSecret ||
+    request.headers.get("Authorization") !== `Bearer ${cronSecret}`
+  ) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const cutoff = new Date();
     cutoff.setMonth(cutoff.getMonth() - 6);
 
-    const result = await db
-      .delete(resourceHistory)
-      .where(lt(resourceHistory.createdAt, cutoff));
-
-    const rowsDeleted =
-      (result as unknown as { rowsAffected?: number }).rowsAffected ?? 0;
+    await db.delete(resourceHistory).where(lt(resourceHistory.createdAt, cutoff));
 
     console.log(
-      `[cleanup] Deleted ${rowsDeleted} resource_history entries older than ${cutoff.toISOString()}`,
+      `[cleanup] Pruned resource_history entries older than ${cutoff.toISOString()}`,
     );
 
-    return NextResponse.json({
-      deleted: rowsDeleted,
-      cutoff: cutoff.toISOString(),
-    });
+    return NextResponse.json({ cutoff: cutoff.toISOString() });
   } catch (error) {
     console.error("[cleanup] Failed to prune resource history:", error);
     return NextResponse.json(

--- a/app/api/internal/cleanup/route.ts
+++ b/app/api/internal/cleanup/route.ts
@@ -26,8 +26,9 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const cutoff = new Date();
-    cutoff.setMonth(cutoff.getMonth() - 6);
+    // Use millisecond arithmetic to avoid setMonth() edge cases where the
+    // current day doesn't exist in the target month (e.g. Aug 31 → March 2).
+    const cutoff = new Date(Date.now() - 6 * 30 * 24 * 60 * 60 * 1000);
 
     await db.delete(resourceHistory).where(lt(resourceHistory.createdAt, cutoff));
 

--- a/app/api/internal/leaderboard/route.ts
+++ b/app/api/internal/leaderboard/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getLeaderboard } from "@/lib/leaderboard";
-import { db, users } from "@/lib/db";
-import { inArray } from "drizzle-orm";
+import { resolveDisplayNames } from "@/lib/users";
 
 export const dynamic = "force-dynamic";
 
@@ -44,26 +43,9 @@ export async function GET(request: NextRequest) {
 
     const result = await getLeaderboard(timeFilter, effectiveLimit, offset);
 
-    // Resolve Discord IDs to display names; old entries (stored as nicknames)
-    // won't match discordId and fall back to the stored value.
-    const discordIds = result.rankings.map((r) => r.userId).filter(Boolean);
-    let displayNameMap: Record<string, string> = {};
-    if (discordIds.length > 0) {
-      const usersResult = await db
-        .select({
-          discordId: users.discordId,
-          customNickname: users.customNickname,
-          username: users.username,
-        })
-        .from(users)
-        .where(inArray(users.discordId, discordIds));
-      displayNameMap = Object.fromEntries(
-        usersResult.map((u) => [
-          u.discordId,
-          u.customNickname || u.username,
-        ]),
-      );
-    }
+    const displayNameMap = await resolveDisplayNames(
+      result.rankings.map((r) => r.userId).filter(Boolean),
+    );
 
     const rankingsWithNames = result.rankings.map((r) => ({
       ...r,

--- a/app/api/internal/leaderboard/route.ts
+++ b/app/api/internal/leaderboard/route.ts
@@ -44,7 +44,7 @@ export async function GET(request: NextRequest) {
     const result = await getLeaderboard(timeFilter, effectiveLimit, offset);
 
     const displayNameMap = await resolveDisplayNames(
-      result.rankings.map((r) => r.userId).filter(Boolean),
+      [...new Set(result.rankings.map((r) => r.userId))],
     );
 
     const rankingsWithNames = result.rankings.map((r) => ({

--- a/app/api/internal/leaderboard/route.ts
+++ b/app/api/internal/leaderboard/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getLeaderboard } from "@/lib/leaderboard";
+import { db, users } from "@/lib/db";
+import { inArray } from "drizzle-orm";
 
 export const dynamic = "force-dynamic";
 
@@ -42,8 +44,34 @@ export async function GET(request: NextRequest) {
 
     const result = await getLeaderboard(timeFilter, effectiveLimit, offset);
 
+    // Resolve Discord IDs to display names; old entries (stored as nicknames)
+    // won't match discordId and fall back to the stored value.
+    const discordIds = result.rankings.map((r) => r.userId).filter(Boolean);
+    let displayNameMap: Record<string, string> = {};
+    if (discordIds.length > 0) {
+      const usersResult = await db
+        .select({
+          discordId: users.discordId,
+          customNickname: users.customNickname,
+          username: users.username,
+        })
+        .from(users)
+        .where(inArray(users.discordId, discordIds));
+      displayNameMap = Object.fromEntries(
+        usersResult.map((u) => [
+          u.discordId,
+          u.customNickname || u.username,
+        ]),
+      );
+    }
+
+    const rankingsWithNames = result.rankings.map((r) => ({
+      ...r,
+      displayName: displayNameMap[r.userId] || r.userId,
+    }));
+
     return NextResponse.json({
-      leaderboard: result.rankings,
+      leaderboard: rankingsWithNames,
       timeFilter,
       total: result.total,
       page,

--- a/app/api/internal/resources/[id]/history/route.ts
+++ b/app/api/internal/resources/[id]/history/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
-import { db, resourceHistory, users } from "@/lib/db";
-import { eq, gte, desc, and, inArray } from "drizzle-orm";
+import { db, resourceHistory } from "@/lib/db";
+import { eq, gte, desc, and } from "drizzle-orm";
 import { hasResourceAccess } from "@/lib/discord-roles";
 import { mapHistoryRowForRead } from "@/lib/resource-mapping";
+import { resolveDisplayNames } from "@/lib/users";
 
 export const dynamic = "force-dynamic";
 
@@ -54,25 +55,9 @@ export async function GET(
       .orderBy(desc(resourceHistory.createdAt))
       .limit(100); // Limit to reduce load
 
-    // Resolve Discord IDs to display names; entries stored before the migration
-    // (with nicknames as updatedBy) won't match and fall back to the stored value.
-    const updaterIds = [...new Set(history.map((h) => h.updatedBy))].filter(
-      Boolean,
+    const displayNameMap = await resolveDisplayNames(
+      [...new Set(history.map((h) => h.updatedBy))].filter(Boolean),
     );
-    let displayNameMap: Record<string, string> = {};
-    if (updaterIds.length > 0) {
-      const usersResult = await db
-        .select({
-          discordId: users.discordId,
-          customNickname: users.customNickname,
-          username: users.username,
-        })
-        .from(users)
-        .where(inArray(users.discordId, updaterIds));
-      displayNameMap = Object.fromEntries(
-        usersResult.map((u) => [u.discordId, u.customNickname || u.username]),
-      );
-    }
 
     const mapped = history.map((row) => ({
       ...mapHistoryRowForRead(row),

--- a/app/api/internal/resources/[id]/history/route.ts
+++ b/app/api/internal/resources/[id]/history/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
-import { db, resourceHistory } from "@/lib/db";
-import { eq, gte, desc, and } from "drizzle-orm";
+import { db, resourceHistory, users } from "@/lib/db";
+import { eq, gte, desc, and, inArray } from "drizzle-orm";
 import { hasResourceAccess } from "@/lib/discord-roles";
 import { mapHistoryRowForRead } from "@/lib/resource-mapping";
 
@@ -54,7 +54,32 @@ export async function GET(
       .orderBy(desc(resourceHistory.createdAt))
       .limit(100); // Limit to reduce load
 
-    return NextResponse.json(history.map(mapHistoryRowForRead));
+    // Resolve Discord IDs to display names; entries stored before the migration
+    // (with nicknames as updatedBy) won't match and fall back to the stored value.
+    const updaterIds = [...new Set(history.map((h) => h.updatedBy))].filter(
+      Boolean,
+    );
+    let displayNameMap: Record<string, string> = {};
+    if (updaterIds.length > 0) {
+      const usersResult = await db
+        .select({
+          discordId: users.discordId,
+          customNickname: users.customNickname,
+          username: users.username,
+        })
+        .from(users)
+        .where(inArray(users.discordId, updaterIds));
+      displayNameMap = Object.fromEntries(
+        usersResult.map((u) => [u.discordId, u.customNickname || u.username]),
+      );
+    }
+
+    const mapped = history.map((row) => ({
+      ...mapHistoryRowForRead(row),
+      updatedBy: displayNameMap[row.updatedBy] || row.updatedBy,
+    }));
+
+    return NextResponse.json(mapped);
   } catch (error) {
     console.error("Error fetching resource history:", error);
     return NextResponse.json(

--- a/app/api/internal/resources/route.ts
+++ b/app/api/internal/resources/route.ts
@@ -30,16 +30,18 @@ export async function GET(request: NextRequest) {
     const allResources = await db.select().from(resources);
     const mapped = allResources.map(mapResourceRowForRead);
 
-    const displayNameMap = await resolveDisplayNames(
-      [...new Set(mapped.map((r) => r.lastUpdatedBy as string))].filter(Boolean),
-    );
+    const lastUpdatedByIds = mapped
+      .map((r) => r.lastUpdatedBy)
+      .filter((id): id is string => typeof id === "string" && id.length > 0);
+    const displayNameMap = await resolveDisplayNames([...new Set(lastUpdatedByIds)]);
 
     return NextResponse.json(
       mapped.map((r) => ({
         ...r,
         lastUpdatedBy:
-          displayNameMap[r.lastUpdatedBy as string] ||
-          (r.lastUpdatedBy as string),
+          typeof r.lastUpdatedBy === "string"
+            ? displayNameMap[r.lastUpdatedBy] || r.lastUpdatedBy
+            : r.lastUpdatedBy,
       })),
     );
   } catch (error) {

--- a/app/api/internal/resources/route.ts
+++ b/app/api/internal/resources/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
-import { db, resources, users } from "@/lib/db";
-import { inArray } from "drizzle-orm";
+import { db, resources } from "@/lib/db";
 import { hasResourceAccess } from "@/lib/discord-roles";
 import { mapResourceRowForRead } from "@/lib/resource-mapping";
+import { resolveDisplayNames } from "@/lib/users";
 
 export const dynamic = "force-dynamic";
 
@@ -30,25 +30,9 @@ export async function GET(request: NextRequest) {
     const allResources = await db.select().from(resources);
     const mapped = allResources.map(mapResourceRowForRead);
 
-    // Resolve Discord IDs in lastUpdatedBy to display names; entries stored
-    // before the migration (with nicknames) won't match and fall back as-is.
-    const updaterIds = [
-      ...new Set(mapped.map((r) => r.lastUpdatedBy as string)),
-    ].filter(Boolean);
-    let displayNameMap: Record<string, string> = {};
-    if (updaterIds.length > 0) {
-      const usersResult = await db
-        .select({
-          discordId: users.discordId,
-          customNickname: users.customNickname,
-          username: users.username,
-        })
-        .from(users)
-        .where(inArray(users.discordId, updaterIds));
-      displayNameMap = Object.fromEntries(
-        usersResult.map((u) => [u.discordId, u.customNickname || u.username]),
-      );
-    }
+    const displayNameMap = await resolveDisplayNames(
+      [...new Set(mapped.map((r) => r.lastUpdatedBy as string))].filter(Boolean),
+    );
 
     return NextResponse.json(
       mapped.map((r) => ({

--- a/app/api/internal/resources/route.ts
+++ b/app/api/internal/resources/route.ts
@@ -33,7 +33,9 @@ export async function GET(request: NextRequest) {
     const lastUpdatedByIds = mapped
       .map((r) => r.lastUpdatedBy)
       .filter((id): id is string => typeof id === "string" && id.length > 0);
-    const displayNameMap = await resolveDisplayNames([...new Set(lastUpdatedByIds)]);
+    const displayNameMap = await resolveDisplayNames([
+      ...new Set(lastUpdatedByIds),
+    ]);
 
     return NextResponse.json(
       mapped.map((r) => ({

--- a/app/api/internal/resources/route.ts
+++ b/app/api/internal/resources/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
-import { db, resources } from "@/lib/db";
+import { db, resources, users } from "@/lib/db";
+import { inArray } from "drizzle-orm";
 import { hasResourceAccess } from "@/lib/discord-roles";
 import { mapResourceRowForRead } from "@/lib/resource-mapping";
 
@@ -27,8 +28,36 @@ export async function GET(request: NextRequest) {
 
   try {
     const allResources = await db.select().from(resources);
+    const mapped = allResources.map(mapResourceRowForRead);
 
-    return NextResponse.json(allResources.map(mapResourceRowForRead));
+    // Resolve Discord IDs in lastUpdatedBy to display names; entries stored
+    // before the migration (with nicknames) won't match and fall back as-is.
+    const updaterIds = [
+      ...new Set(mapped.map((r) => r.lastUpdatedBy as string)),
+    ].filter(Boolean);
+    let displayNameMap: Record<string, string> = {};
+    if (updaterIds.length > 0) {
+      const usersResult = await db
+        .select({
+          discordId: users.discordId,
+          customNickname: users.customNickname,
+          username: users.username,
+        })
+        .from(users)
+        .where(inArray(users.discordId, updaterIds));
+      displayNameMap = Object.fromEntries(
+        usersResult.map((u) => [u.discordId, u.customNickname || u.username]),
+      );
+    }
+
+    return NextResponse.json(
+      mapped.map((r) => ({
+        ...r,
+        lastUpdatedBy:
+          displayNameMap[r.lastUpdatedBy as string] ||
+          (r.lastUpdatedBy as string),
+      })),
+    );
   } catch (error) {
     console.error("Error fetching resources:", error);
     return NextResponse.json(

--- a/app/api/internal/user/activity/route.ts
+++ b/app/api/internal/user/activity/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { db, resourceHistory, resources, users } from "@/lib/db";
-import { eq, gte, desc, and, or, inArray } from "drizzle-orm";
+import { db, resourceHistory, resources } from "@/lib/db";
+import { eq, gte, desc, and, or } from "drizzle-orm";
 import {
   mapCategoryForRead,
   mapTransferDirectionForRead,
 } from "@/lib/resource-mapping";
+import { resolveDisplayNames } from "@/lib/users";
 
 export const dynamic = "force-dynamic";
 
@@ -97,25 +98,9 @@ export async function GET(request: NextRequest) {
       .orderBy(desc(resourceHistory.createdAt))
       .limit(limit);
 
-    // Resolve Discord IDs to display names; entries stored before the migration
-    // (with nicknames as updatedBy) won't match and fall back to the stored value.
-    const updaterIds = [...new Set(activity.map((a) => a.updatedBy))].filter(
-      Boolean,
+    const displayNameMap = await resolveDisplayNames(
+      [...new Set(activity.map((a) => a.updatedBy))].filter(Boolean),
     );
-    let displayNameMap: Record<string, string> = {};
-    if (updaterIds.length > 0) {
-      const usersResult = await db
-        .select({
-          discordId: users.discordId,
-          customNickname: users.customNickname,
-          username: users.username,
-        })
-        .from(users)
-        .where(inArray(users.discordId, updaterIds));
-      displayNameMap = Object.fromEntries(
-        usersResult.map((u) => [u.discordId, u.customNickname || u.username]),
-      );
-    }
 
     const processedActivity = activity.map((entry) => {
       const loc1Amount =

--- a/app/api/internal/user/activity/route.ts
+++ b/app/api/internal/user/activity/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { db, resourceHistory, resources } from "@/lib/db";
-import { eq, gte, desc, and, or } from "drizzle-orm";
+import { db, resourceHistory, resources, users } from "@/lib/db";
+import { eq, gte, desc, and, or, inArray } from "drizzle-orm";
 import {
   mapCategoryForRead,
   mapTransferDirectionForRead,
@@ -97,6 +97,26 @@ export async function GET(request: NextRequest) {
       .orderBy(desc(resourceHistory.createdAt))
       .limit(limit);
 
+    // Resolve Discord IDs to display names; entries stored before the migration
+    // (with nicknames as updatedBy) won't match and fall back to the stored value.
+    const updaterIds = [...new Set(activity.map((a) => a.updatedBy))].filter(
+      Boolean,
+    );
+    let displayNameMap: Record<string, string> = {};
+    if (updaterIds.length > 0) {
+      const usersResult = await db
+        .select({
+          discordId: users.discordId,
+          customNickname: users.customNickname,
+          username: users.username,
+        })
+        .from(users)
+        .where(inArray(users.discordId, updaterIds));
+      displayNameMap = Object.fromEntries(
+        usersResult.map((u) => [u.discordId, u.customNickname || u.username]),
+      );
+    }
+
     const processedActivity = activity.map((entry) => {
       const loc1Amount =
         entry.changeAmountLocation1 ?? entry.changeAmountHagga ?? 0;
@@ -105,6 +125,7 @@ export async function GET(request: NextRequest) {
       const totalChangeAmount = loc1Amount + loc2Amount;
       return {
         ...entry,
+        updatedBy: displayNameMap[entry.updatedBy] || entry.updatedBy,
         resourceCategory: mapCategoryForRead(entry.resourceCategory),
         previousQuantityLocation1:
           entry.previousQuantityLocation1 ??

--- a/app/api/resources/[id]/route.ts
+++ b/app/api/resources/[id]/route.ts
@@ -136,9 +136,11 @@ export async function PUT(
       // Use the Discord ID for stable tracking — display name resolved at read time
       effectiveUserId = targetUser[0].discordId;
 
-      // Append a human-readable audit note using the acting admin's display name
+      // Append a human-readable audit note using the acting admin's display name.
+      // Fallback to "Unknown Admin" so a raw Discord snowflake never surfaces in
+      // stored history if somehow both nickname and username are absent.
       const actingDisplayName =
-        session.user?.discordNickname || session.user?.name || actingUserIdentifier;
+        session.user?.discordNickname || session.user?.name || "Unknown Admin";
       const auditNote = ` (entered by ${actingDisplayName})`;
       if (reason) {
         const maxBase = 500 - auditNote.length;

--- a/app/api/resources/[id]/route.ts
+++ b/app/api/resources/[id]/route.ts
@@ -117,12 +117,11 @@ export async function PUT(
 
     let effectiveUserId = actingUserIdentifier;
 
-    // If an admin is acting on behalf of another user, look up that user's display name
+    // If an admin is acting on behalf of another user, look up that user's Discord ID
     if (onBehalfOf && hasResourceAdminAccess(session.user.roles)) {
       const targetUser = await db
         .select({
-          username: users.username,
-          customNickname: users.customNickname,
+          discordId: users.discordId,
         })
         .from(users)
         .where(eq(users.id, onBehalfOf));
@@ -134,11 +133,13 @@ export async function PUT(
         );
       }
 
-      // Use the display name for consistency in history and leaderboards
-      effectiveUserId = targetUser[0].customNickname || targetUser[0].username;
+      // Use the Discord ID for stable tracking — display name resolved at read time
+      effectiveUserId = targetUser[0].discordId;
 
-      // Append an audit note to the reason, staying within the 500-char limit
-      const auditNote = ` (entered by ${actingUserIdentifier})`;
+      // Append a human-readable audit note using the acting admin's display name
+      const actingDisplayName =
+        session.user?.discordNickname || session.user?.name || actingUserIdentifier;
+      const auditNote = ` (entered by ${actingDisplayName})`;
       if (reason) {
         const maxBase = 500 - auditNote.length;
         reason =

--- a/app/api/user/activity/route.ts
+++ b/app/api/user/activity/route.ts
@@ -22,10 +22,12 @@ export async function GET(request: NextRequest) {
 
   const { searchParams } = new URL(request.url);
   const userId = getUserIdentifier(session);
+  // Include old-style identifiers (nicknames, usernames, email) so history
+  // recorded before the Discord-ID migration is still returned for this user.
   const oldUserIds = [
-    session.user.id,
-    session.user.email,
+    session.user.discordNickname,
     session.user.name,
+    session.user.email,
     "unknown",
   ]
     .filter(Boolean)

--- a/app/api/user/data-deletion/route.ts
+++ b/app/api/user/data-deletion/route.ts
@@ -27,11 +27,12 @@ export async function POST(request: NextRequest) {
   try {
     const userId = getUserIdentifier(session);
 
-    // For backward compatibility, also check for old user identifiers
+    // For backward compatibility, also check for old user identifiers.
+    // discordNickname was the primary stored value before the Discord-ID migration.
     const oldUserIds = [
-      session.user.id,
-      session.user.email,
+      session.user.discordNickname,
       session.user.name,
+      session.user.email,
       "unknown",
     ].filter(Boolean);
 

--- a/app/api/user/data-export/route.ts
+++ b/app/api/user/data-export/route.ts
@@ -25,11 +25,12 @@ export async function GET(request: NextRequest) {
   try {
     const userId = getUserIdentifier(session);
 
-    // For backward compatibility, also check for old user identifiers
+    // For backward compatibility, also check for old user identifiers.
+    // discordNickname was the primary stored value before the Discord-ID migration.
     const oldUserIds = [
-      session.user.id,
-      session.user.email,
+      session.user.discordNickname,
       session.user.name,
+      session.user.email,
       "unknown",
     ].filter(Boolean);
 

--- a/app/components/ResourceTable.tsx
+++ b/app/components/ResourceTable.tsx
@@ -353,6 +353,7 @@ interface PointsCalculation {
 
 interface LeaderboardEntry {
   userId: string;
+  displayName: string;
   totalPoints: number;
   totalActions: number;
 }
@@ -1307,7 +1308,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                     onClick={() =>
                       router.push(`/dashboard/contributions/${entry.userId}`)
                     }
-                    title={`Click to view ${entry.userId}'s detailed contributions`}
+                    title={`Click to view ${entry.displayName}'s detailed contributions`}
                   >
                     <div className="flex items-center gap-3">
                       <div
@@ -1324,7 +1325,7 @@ export function ResourceTable({ userId }: ResourceTableProps) {
                         #{index + 1}
                       </div>
                       <div className="text-sm font-medium text-text-primary">
-                        {entry.userId}
+                        {entry.displayName}
                       </div>
                       <div className="text-xs text-text-quaternary">
                         ({entry.totalActions} actions)

--- a/app/dashboard/leaderboard/page.tsx
+++ b/app/dashboard/leaderboard/page.tsx
@@ -9,6 +9,7 @@ import { AppShell } from "@/app/components/AppShell";
 
 interface LeaderboardEntry {
   userId: string;
+  displayName: string;
   totalPoints: number;
   totalActions: number;
 }
@@ -217,7 +218,7 @@ export default function LeaderboardPage() {
                           </div>
                           <div>
                             <h3 className="font-medium text-text-primary">
-                              {entry.userId}
+                              {entry.displayName}
                             </h3>
                             <div className="mt-1 flex items-center gap-4 text-sm text-text-quaternary">
                               <span>{entry.totalActions} actions</span>

--- a/app/resources/[id]/page.tsx
+++ b/app/resources/[id]/page.tsx
@@ -1762,7 +1762,7 @@ export default function ResourceDetailPage() {
                     onClick={() =>
                       router.push(`/dashboard/contributions/${entry.userId}`)
                     }
-                    title={`Click to view ${entry.userId}&apos;s detailed contributions`}
+                    title={`Click to view ${entry.displayName ?? entry.userId}&apos;s detailed contributions`}
                   >
                     <div className="flex items-center gap-3">
                       <div
@@ -1779,7 +1779,7 @@ export default function ResourceDetailPage() {
                         #{index + 1}
                       </div>
                       <div className="text-sm font-medium text-text-primary">
-                        {entry.userId}
+                        {entry.displayName ?? entry.userId}
                       </div>
                       <div className="text-xs text-text-quaternary">
                         ({entry.totalActions} actions)

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -262,12 +262,12 @@ export const authOptions: NextAuthOptions = {
       return token;
     },
     async session({ session, token }) {
-      // Explicitly surface the Discord user ID so getUserIdentifier() can
-      // use a stable, rename-proof identifier for all database records.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (session.user as any).id = token.sub;
       session.user = {
         ...session.user,
+        // Surface the Discord user ID (token.sub) as session.user.id so
+        // getUserIdentifier() has a stable, rename-proof key for DB records.
+        // Cast is safe: token.sub is always set for authenticated sessions.
+        id: token.sub as string,
         roles: (token.userRoles || []) as string[],
         isInGuild: Boolean(token.isInGuild),
         discordNickname: token.discordNickname as string | null,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -262,6 +262,10 @@ export const authOptions: NextAuthOptions = {
       return token;
     },
     async session({ session, token }) {
+      // Explicitly surface the Discord user ID so getUserIdentifier() can
+      // use a stable, rename-proof identifier for all database records.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (session.user as any).id = token.sub;
       session.user = {
         ...session.user,
         roles: (token.userRoles || []) as string[],
@@ -328,20 +332,18 @@ export function getDisplayName(user: {
 }
 
 /**
- * Returns the best available identifier for a user, used for database tracking.
+ * Returns the Discord user ID for database tracking.
  *
- * Priority order: Discord nickname → Discord username → email → user ID → `"unknown"`.
+ * Uses the Discord user ID (token.sub) so that history records remain stable
+ * even when a user changes their nickname or username. Display names are
+ * resolved at read time via the users table.
+ *
+ * Falls back to `"unknown"` only if no session ID is present (e.g. dev agent
+ * sessions that have not been assigned a real Discord ID).
  *
  * @param session - The NextAuth session object
- * @returns A string identifier for the user
+ * @returns The Discord user ID (or dev agent ID), used as the stable identifier
  */
 export function getUserIdentifier(session: Session): string {
-  // Priority: Discord nickname > Discord username > email > id > fallback
-  return (
-    session.user?.discordNickname ??
-    session.user?.name ??
-    session.user?.email ??
-    session.user?.id ??
-    "unknown"
-  );
+  return session.user?.id ?? "unknown";
 }

--- a/lib/changelog.json
+++ b/lib/changelog.json
@@ -1,6 +1,26 @@
 {
-  "currentVersion": "4.5.0",
+  "currentVersion": "4.5.1",
   "releases": [
+    {
+      "version": "4.5.1",
+      "date": "2026-05-13",
+      "title": "Stable user IDs in history and leaderboard",
+      "type": "patch",
+      "changes": [
+        {
+          "type": "improvement",
+          "description": "Resource history, leaderboard, and resource 'last updated by' records now store the Discord user ID instead of the server nickname. Display names are resolved at read time from the users table, so nickname or username changes are automatically reflected going forward without rewriting history."
+        },
+        {
+          "type": "improvement",
+          "description": "Added a rolling 6-month cleanup of resource_history entries via a scheduled Vercel cron job (runs on the 1st of each month). History charts only go back 3 months and current quantities are always preserved in the resource table, so older entries are safe to prune."
+        },
+        {
+          "type": "bugfix",
+          "description": "Leaderboard and activity history entries recorded under a user's old nickname are still returned correctly through backward-compatible identifier lookup."
+        }
+      ]
+    },
     {
       "version": "4.5.0",
       "date": "2026-05-01",

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -12,9 +12,10 @@ import { inArray } from "drizzle-orm";
  * Accepts an empty array gracefully (returns an empty map without querying).
  */
 export async function resolveDisplayNames(
-  discordIds: string[],
+  discordIds: (string | null | undefined)[],
 ): Promise<Record<string, string>> {
-  if (discordIds.length === 0) return {};
+  const ids = discordIds.filter((id): id is string => !!id);
+  if (ids.length === 0) return {};
   const rows = await db
     .select({
       discordId: users.discordId,
@@ -22,7 +23,7 @@ export async function resolveDisplayNames(
       username: users.username,
     })
     .from(users)
-    .where(inArray(users.discordId, discordIds));
+    .where(inArray(users.discordId, ids));
   return Object.fromEntries(
     rows.map((u) => [u.discordId, u.customNickname || u.username]),
   );

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -14,7 +14,7 @@ import { inArray } from "drizzle-orm";
 export async function resolveDisplayNames(
   discordIds: (string | null | undefined)[],
 ): Promise<Record<string, string>> {
-  const ids = discordIds.filter((id): id is string => !!id);
+  const ids = [...new Set(discordIds.filter((id): id is string => !!id))];
   if (ids.length === 0) return {};
   const rows = await db
     .select({

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,0 +1,29 @@
+import { db, users } from "./db";
+import { inArray } from "drizzle-orm";
+
+/**
+ * Batch-resolves Discord IDs to display names using the users table.
+ *
+ * Returns a map of `discordId → displayName` (customNickname falling back to
+ * username). IDs that have no matching row are absent from the map; callers
+ * should fall back to the raw stored value for those (pre-migration entries
+ * that still contain a nickname string rather than a Discord ID).
+ *
+ * Accepts an empty array gracefully (returns an empty map without querying).
+ */
+export async function resolveDisplayNames(
+  discordIds: string[],
+): Promise<Record<string, string>> {
+  if (discordIds.length === 0) return {};
+  const rows = await db
+    .select({
+      discordId: users.discordId,
+      customNickname: users.customNickname,
+      username: users.username,
+    })
+    .from(users)
+    .where(inArray(users.discordId, discordIds));
+  return Object.fromEntries(
+    rows.map((u) => [u.discordId, u.customNickname || u.username]),
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11901,6 +11901,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,18 +22,18 @@
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-icons": "^5.6.0",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.3",
         "@playwright/test": "^1.59.1",
         "@swc/jest": "^0.2.39",
-        "@tailwindcss/postcss": "^4.2.4",
+        "@tailwindcss/postcss": "^4.3.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^30.0.0",
-        "@types/node": "^25.6.2",
+        "@types/node": "^25.7.0",
         "@types/papaparse": "^5.5.2",
         "@types/react": "^19.2.14",
         "cross-env": "^10.1.0",
@@ -45,10 +45,10 @@
         "jest-environment-jsdom": "^30.4.1",
         "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.8.0",
-        "tailwindcss": "^4.2.4",
+        "tailwindcss": "^4.3.0",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2",
-        "typescript-eslint": "^8.59.2"
+        "typescript-eslint": "^8.59.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3964,49 +3964,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
-      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.19.0",
+        "enhanced-resolve": "^5.21.0",
         "jiti": "^2.6.1",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.4"
+        "tailwindcss": "4.3.0"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
-      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-x64": "4.2.4",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
-      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
       "cpu": [
         "arm64"
       ],
@@ -4021,9 +4021,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
-      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
       "cpu": [
         "arm64"
       ],
@@ -4038,9 +4038,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
-      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
       "cpu": [
         "x64"
       ],
@@ -4055,9 +4055,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
-      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
       "cpu": [
         "x64"
       ],
@@ -4072,9 +4072,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
-      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
       "cpu": [
         "arm"
       ],
@@ -4089,9 +4089,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
-      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
       "cpu": [
         "arm64"
       ],
@@ -4106,9 +4106,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
-      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
       ],
@@ -4123,9 +4123,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
-      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
       "cpu": [
         "x64"
       ],
@@ -4140,9 +4140,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
-      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
       ],
@@ -4157,9 +4157,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
-      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -4175,10 +4175,10 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.8.1",
-        "@emnapi/runtime": "^1.8.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
         "@tybys/wasm-util": "^0.10.1",
         "tslib": "^2.8.1"
       },
@@ -4186,74 +4186,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
-      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
       "cpu": [
         "arm64"
       ],
@@ -4268,9 +4204,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
-      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
       "cpu": [
         "x64"
       ],
@@ -4285,17 +4221,17 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.4.tgz",
-      "integrity": "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.0.tgz",
+      "integrity": "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.2.4",
-        "@tailwindcss/oxide": "4.2.4",
-        "postcss": "^8.5.6",
-        "tailwindcss": "4.2.4"
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "postcss": "^8.5.10",
+        "tailwindcss": "4.3.0"
       }
     },
     "node_modules/@tanstack/react-virtual": {
@@ -4593,12 +4529,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
-      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~7.21.0"
       }
     },
     "node_modules/@types/papaparse": {
@@ -4662,17 +4598,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/type-utils": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -4685,7 +4621,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.2",
+        "@typescript-eslint/parser": "^8.59.3",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -4701,16 +4637,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4726,14 +4662,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.2",
-        "@typescript-eslint/types": "^8.59.2",
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4748,14 +4684,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2"
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4766,9 +4702,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4783,15 +4719,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -4808,9 +4744,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4822,16 +4758,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.2",
-        "@typescript-eslint/tsconfig-utils": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4866,16 +4802,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2"
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4890,13 +4826,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/types": "8.59.3",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -6491,9 +6427,9 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
-      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "version": "5.21.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
+      "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13195,9 +13131,9 @@
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
-      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -13205,9 +13141,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
-      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -14033,16 +13969,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
-      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.2",
-        "@typescript-eslint/parser": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2"
+        "@typescript-eslint/eslint-plugin": "8.59.3",
+        "@typescript-eslint/parser": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -14076,9 +14012,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-icons": "^5.6.0",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.6.0"
   },
   "overrides": {
     "nodemailer": "^7.0.7",
@@ -52,12 +52,12 @@
     "@eslint/eslintrc": "^3.3.3",
     "@playwright/test": "^1.59.1",
     "@swc/jest": "^0.2.39",
-    "@tailwindcss/postcss": "^4.2.4",
+    "@tailwindcss/postcss": "^4.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.6.2",
+    "@types/node": "^25.7.0",
     "@types/papaparse": "^5.5.2",
     "@types/react": "^19.2.14",
     "cross-env": "^10.1.0",
@@ -69,9 +69,9 @@
     "jest-environment-jsdom": "^30.4.1",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
-    "tailwindcss": "^4.2.4",
+    "tailwindcss": "^4.3.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
-    "typescript-eslint": "^8.59.2"
+    "typescript-eslint": "^8.59.3"
   }
 }

--- a/tests/api/internal/leaderboard/route.test.ts
+++ b/tests/api/internal/leaderboard/route.test.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from "next/server";
 import { jest } from "@jest/globals";
 
-const mockDbSelect = jest.fn();
+const mockResolveDisplayNames = jest.fn();
 
 describe("GET /api/internal/leaderboard", () => {
   let consoleErrorSpy: jest.SpyInstance;
@@ -14,20 +14,10 @@ describe("GET /api/internal/leaderboard", () => {
     jest.clearAllMocks();
     consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-    // Mock db so the display-name lookup doesn't try a real connection.
-    // Return an empty users list so displayName falls back to userId.
-    mockDbSelect.mockReturnValue({
-      from: jest.fn().mockReturnValue({
-        where: jest.fn().mockResolvedValue([]),
-      }),
-    });
-    jest.doMock("@/lib/db", () => ({
-      db: { select: mockDbSelect },
-      users: {
-        discordId: "users.discordId",
-        customNickname: "users.customNickname",
-        username: "users.username",
-      },
+    // Default: no users matched → displayName falls back to userId
+    mockResolveDisplayNames.mockResolvedValue({});
+    jest.doMock("@/lib/users", () => ({
+      resolveDisplayNames: mockResolveDisplayNames,
     }));
   });
 
@@ -65,7 +55,7 @@ describe("GET /api/internal/leaderboard", () => {
     });
   });
 
-  it("should call getLeaderboard with provided parameters", async () => {
+  it("should call getLeaderboard with provided parameters and resolve display names", async () => {
     const mockGetLeaderboard = jest.fn().mockResolvedValue({
       rankings: [{ userId: "discord-user-1", totalPoints: 100 }],
       total: 1,
@@ -75,17 +65,8 @@ describe("GET /api/internal/leaderboard", () => {
       getLeaderboard: mockGetLeaderboard,
     }));
 
-    // Return a resolved display name for the Discord ID
-    mockDbSelect.mockReturnValue({
-      from: jest.fn().mockReturnValue({
-        where: jest.fn().mockResolvedValue([
-          {
-            discordId: "discord-user-1",
-            customNickname: "Player One",
-            username: "playerone",
-          },
-        ]),
-      }),
+    mockResolveDisplayNames.mockResolvedValue({
+      "discord-user-1": "Player One",
     });
 
     const { GET } = await import("@/app/api/internal/leaderboard/route");
@@ -121,12 +102,8 @@ describe("GET /api/internal/leaderboard", () => {
       getLeaderboard: mockGetLeaderboard,
     }));
 
-    // No user found for this entry (old pre-migration nickname)
-    mockDbSelect.mockReturnValue({
-      from: jest.fn().mockReturnValue({
-        where: jest.fn().mockResolvedValue([]),
-      }),
-    });
+    // resolveDisplayNames returns empty map → displayName falls back to userId
+    mockResolveDisplayNames.mockResolvedValue({});
 
     const { GET } = await import("@/app/api/internal/leaderboard/route");
     const request = new NextRequest(

--- a/tests/api/internal/leaderboard/route.test.ts
+++ b/tests/api/internal/leaderboard/route.test.ts
@@ -4,6 +4,8 @@
 import { NextRequest } from "next/server";
 import { jest } from "@jest/globals";
 
+const mockDbSelect = jest.fn();
+
 describe("GET /api/internal/leaderboard", () => {
   let consoleErrorSpy: jest.SpyInstance;
 
@@ -11,6 +13,22 @@ describe("GET /api/internal/leaderboard", () => {
     jest.resetModules();
     jest.clearAllMocks();
     consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    // Mock db so the display-name lookup doesn't try a real connection.
+    // Return an empty users list so displayName falls back to userId.
+    mockDbSelect.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    jest.doMock("@/lib/db", () => ({
+      db: { select: mockDbSelect },
+      users: {
+        discordId: "users.discordId",
+        customNickname: "users.customNickname",
+        username: "users.username",
+      },
+    }));
   });
 
   afterEach(() => {
@@ -49,13 +67,26 @@ describe("GET /api/internal/leaderboard", () => {
 
   it("should call getLeaderboard with provided parameters", async () => {
     const mockGetLeaderboard = jest.fn().mockResolvedValue({
-      rankings: [{ userId: "1", totalPoints: 100 }],
+      rankings: [{ userId: "discord-user-1", totalPoints: 100 }],
       total: 1,
     });
     jest.doMock("@/lib/leaderboard", () => ({
       ...jest.requireActual("@/lib/leaderboard"),
       getLeaderboard: mockGetLeaderboard,
     }));
+
+    // Return a resolved display name for the Discord ID
+    mockDbSelect.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue([
+          {
+            discordId: "discord-user-1",
+            customNickname: "Player One",
+            username: "playerone",
+          },
+        ]),
+      }),
+    });
 
     const { GET } = await import("@/app/api/internal/leaderboard/route");
     const request = new NextRequest(
@@ -67,7 +98,9 @@ describe("GET /api/internal/leaderboard", () => {
     expect(response.status).toBe(200);
     expect(mockGetLeaderboard).toHaveBeenCalledWith("7d", 10, 5);
     expect(body).toEqual({
-      leaderboard: [{ userId: "1", totalPoints: 100 }],
+      leaderboard: [
+        { userId: "discord-user-1", totalPoints: 100, displayName: "Player One" },
+      ],
       timeFilter: "7d",
       total: 1,
       page: 2,
@@ -75,6 +108,38 @@ describe("GET /api/internal/leaderboard", () => {
       totalPages: 1,
       hasNextPage: false,
       hasPrevPage: true,
+    });
+  });
+
+  it("falls back to userId when Discord ID has no matching user record", async () => {
+    const mockGetLeaderboard = jest.fn().mockResolvedValue({
+      rankings: [{ userId: "old-nickname", totalPoints: 50 }],
+      total: 1,
+    });
+    jest.doMock("@/lib/leaderboard", () => ({
+      ...jest.requireActual("@/lib/leaderboard"),
+      getLeaderboard: mockGetLeaderboard,
+    }));
+
+    // No user found for this entry (old pre-migration nickname)
+    mockDbSelect.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue([]),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/internal/leaderboard/route");
+    const request = new NextRequest(
+      "http://localhost/api/internal/leaderboard",
+    );
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.leaderboard[0]).toEqual({
+      userId: "old-nickname",
+      totalPoints: 50,
+      displayName: "old-nickname",
     });
   });
 

--- a/tests/api/resources/[id]/route.test.ts
+++ b/tests/api/resources/[id]/route.test.ts
@@ -17,7 +17,7 @@ jest.mock("@/lib/db", () => ({
   resources: { id: "id" },
   resourceHistory: { resourceId: "resourceId" },
   leaderboard: { resourceId: "resourceId" },
-  users: { id: "id", username: "username", customNickname: "customNickname" },
+  users: { id: "id", discordId: "discordId", username: "username", customNickname: "customNickname" },
 }));
 jest.mock("@/lib/discord-roles");
 jest.mock("nanoid");
@@ -104,9 +104,7 @@ describe("API Routes: /api/resources/[id]", () => {
       };
       const updatedResource = { ...initialResource, quantityHagga: 120 };
       mockDbExecution
-        .mockResolvedValueOnce([
-          { username: "testuser", customNickname: "TestUser" },
-        ]) // User lookup
+        .mockResolvedValueOnce([{ discordId: "discord-user-2" }]) // User lookup
         .mockResolvedValueOnce([initialResource]) // First select in transaction
         .mockResolvedValueOnce(undefined) // update
         .mockResolvedValueOnce(undefined) // insert history
@@ -117,7 +115,7 @@ describe("API Routes: /api/resources/[id]", () => {
 
       expect(db.insert).toHaveBeenCalled();
       expect(db.values).toHaveBeenCalledWith(
-        expect.objectContaining({ updatedBy: "TestUser" }),
+        expect.objectContaining({ updatedBy: "discord-user-2" }),
       );
     });
 

--- a/tests/api/resources/[id]/target/route.test.ts
+++ b/tests/api/resources/[id]/target/route.test.ts
@@ -119,9 +119,10 @@ describe("PUT /api/resources/[id]/target", () => {
 
   it("should successfully update the target quantity", async () => {
     const initialResource = { id: "test-resource-id", targetQuantity: 50 };
+    // getUserIdentifier now returns session.user.id (Discord ID)
     const updatedData = {
       targetQuantity: 100,
-      lastUpdatedBy: "TestUser", // As derived by getUserIdentifier
+      lastUpdatedBy: "test-user-id",
       updatedAt: expect.any(Date),
     };
     const finalResource = { ...initialResource, ...updatedData };
@@ -146,7 +147,7 @@ describe("PUT /api/resources/[id]/target", () => {
     expect(mockDb.update).toHaveBeenCalledWith(resources);
     expect(mockDb.set).toHaveBeenCalledWith(updatedData);
     expect(body.targetQuantity).toBe(100);
-    expect(body.lastUpdatedBy).toBe("TestUser");
+    expect(body.lastUpdatedBy).toBe("test-user-id");
   });
 
   it("should return 500 on database error during initial fetch", async () => {

--- a/tests/app/api/user/activity/route.test.ts
+++ b/tests/app/api/user/activity/route.test.ts
@@ -114,9 +114,11 @@ describe("GET /api/user/activity", () => {
 
     expect(internalUrl.origin).toBe(baseUrl);
     expect(internalUrl.pathname).toBe("/api/internal/user/activity");
-    expect(internalUrl.searchParams.get("userId")).toBe("Test User");
+    // userId is now the Discord ID (session.user.id); old nicknames/names/email
+    // are passed as oldUserIds for backward compatibility with pre-migration history
+    expect(internalUrl.searchParams.get("userId")).toBe("user-123");
     expect(internalUrl.searchParams.get("oldUserIds")).toBe(
-      "user-123,test@example.com,Test User,unknown",
+      "Test User,test@example.com,unknown",
     );
 
     const fetchOptions = fetchCall[1];

--- a/tests/lib/auth.test.ts
+++ b/tests/lib/auth.test.ts
@@ -56,61 +56,25 @@ describe("auth helpers", () => {
   });
 
   describe("getUserIdentifier", () => {
-    const session = {
-      user: {
-        name: "testuser",
-        email: "test@example.com",
-        id: "123",
-        discordNickname: "Test",
-      },
-      expires: "1",
-    };
-
-    it("should return discordNickname if available", () => {
-      expect(getUserIdentifier(session as any)).toBe("Test");
+    it("should return the session user id (Discord ID)", () => {
+      const session = {
+        user: { id: "123456789", name: "testuser", discordNickname: "Test" },
+        expires: "1",
+      };
+      expect(getUserIdentifier(session as any)).toBe("123456789");
     });
 
-    it("should return name if discordNickname is not available", () => {
-      const newSession = {
-        ...session,
-        user: { ...session.user, discordNickname: null },
+    it("should return 'unknown' if session user id is absent", () => {
+      const session = {
+        user: { id: undefined, name: "testuser", discordNickname: "Test" },
+        expires: "1",
       };
-      expect(getUserIdentifier(newSession as any)).toBe("testuser");
+      expect(getUserIdentifier(session as any)).toBe("unknown");
     });
 
-    it("should return email if discordNickname and name are not available", () => {
-      const newSession = {
-        ...session,
-        user: { ...session.user, discordNickname: null, name: null },
-      };
-      expect(getUserIdentifier(newSession as any)).toBe("test@example.com");
-    });
-
-    it("should return id if discordNickname, name, and email are not available", () => {
-      const newSession = {
-        ...session,
-        user: {
-          ...session.user,
-          discordNickname: null,
-          name: null,
-          email: null,
-        },
-      };
-      expect(getUserIdentifier(newSession as any)).toBe("123");
-    });
-
-    it("should return 'unknown' if all are unavailable", () => {
-      const newSession = {
-        ...session,
-        user: {
-          ...session.user,
-          discordNickname: null,
-          name: null,
-          email: null,
-          id: null,
-        },
-      };
-      expect(getUserIdentifier(newSession as any)).toBe("unknown");
+    it("should return 'unknown' if session user is absent", () => {
+      const session = { user: undefined, expires: "1" };
+      expect(getUserIdentifier(session as any)).toBe("unknown");
     });
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
   "framework": "nextjs",
   "buildCommand": "npm run build",
-  "installCommand": "npm install"
+  "installCommand": "npm install",
+  "crons": [
+    {
+      "path": "/api/internal/cleanup",
+      "schedule": "0 3 1 * *"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Refactors user identification throughout the app to store stable Discord user IDs in all history records (leaderboard, resource history, activity) instead of server nicknames. Display names are now resolved at read time from the `users` table, so nickname and username changes are automatically reflected without rewriting history.

## Key Changes

- **`lib/auth.ts`**: Simplified `getUserIdentifier()` to return only the Discord user ID (`session.user.id`), which is now explicitly surfaced in the session callback. This provides a stable, rename-proof identifier for all database records.

- **Leaderboard (`app/api/internal/leaderboard/route.ts`)**: Added Discord ID → display name resolution. Rankings are stored with `userId` as Discord ID; display names are looked up from the `users` table at read time. Old entries (stored as nicknames) fall back gracefully.

- **Resource history (`app/api/internal/resources/[id]/history/route.ts`)**: Similar resolution pattern for `updatedBy` field. Pre-migration entries with nicknames are still returned correctly.

- **Resource updates (`app/api/resources/[id]/route.ts`)**: When an admin acts on behalf of another user, the effective user ID is now the target's Discord ID (not their display name). The audit note in the reason field uses the acting admin's display name for human readability.

- **Resource list (`app/api/internal/resources/route.ts`)**: Added display name resolution for `lastUpdatedBy` field.

- **User activity (`app/api/internal/user/activity/route.ts` and `app/api/user/activity/route.ts`)**: Updated to store Discord IDs and resolve display names at read time. The user activity endpoint now passes `oldUserIds` (nicknames, usernames, email) for backward compatibility with pre-migration history.

- **Cleanup job (`app/api/internal/cleanup/route.ts`)**: New endpoint that deletes `resource_history` entries older than 6 months on a rolling basis. Configured in `vercel.json` to run monthly (1st of each month at 03:00 UTC).

- **Tests**: Updated all affected test suites to mock the new database resolution pattern and verify backward compatibility with old-style identifiers.

- **Changelog**: Added entry for v4.5.1 documenting the stable user ID improvement and cleanup job addition.

## Notable Implementation Details

- Display name resolution uses `inArray()` queries to batch-lookup multiple Discord IDs in a single database call, avoiding N+1 patterns.
- Old entries recorded under a user's nickname (pre-migration) won't match the Discord ID lookup and fall back to the stored value, ensuring no data loss.
- The `users` table is queried with `customNickname || username` priority, matching the existing `getDisplayName()` logic.
- `vercel.json` cron schedule `"0 3 1 * *"` runs at 03:00 UTC on the 1st of each month.

https://claude.ai/code/session_01KxUfitpRLUj2rzvKwvvPNv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scheduled monthly cleanup that prunes resource history older than ~6 months.

* **Improvements**
  * Leaderboard, activity history, resource history, and resource listings now show resolved user display names for clearer attribution.
  * Session user identification standardized to a stable user ID for consistent tracking and attribution.
  * Admin "on behalf of" actions now attribute updates using user IDs for consistent history and scoring.

* **Chores**
  * Version bumped and tests updated to match identifier/display-name behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sininspira2/ResourceTracker/pull/464)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->