### PR TITLE
Fix resource card showing Discord ID after update

### DIFF
--- a/app/api/resources/[id]/route.ts
+++ b/app/api/resources/[id]/route.ts
@@ -16,6 +16,7 @@ import {
   mapCategoryForRead,
   mapResourceRowForRead,
 } from "@/lib/resource-mapping";
+import { resolveDisplayNames } from "@/lib/users";
 
 /**
  * PUT /api/resources/[id]
@@ -274,6 +275,18 @@ export async function PUT(
         pointsCalculation,
       };
     });
+
+    if (result.resource?.lastUpdatedBy) {
+      const displayNameMap = await resolveDisplayNames([
+        result.resource.lastUpdatedBy,
+      ]);
+      result.resource = {
+        ...result.resource,
+        lastUpdatedBy:
+          displayNameMap[result.resource.lastUpdatedBy] ||
+          result.resource.lastUpdatedBy,
+      };
+    }
 
     return NextResponse.json(result, {
       headers: {

--- a/app/api/resources/[id]/route.ts
+++ b/app/api/resources/[id]/route.ts
@@ -277,15 +277,22 @@ export async function PUT(
     });
 
     if (result.resource?.lastUpdatedBy) {
-      const displayNameMap = await resolveDisplayNames([
-        result.resource.lastUpdatedBy,
-      ]);
-      result.resource = {
-        ...result.resource,
-        lastUpdatedBy:
-          displayNameMap[result.resource.lastUpdatedBy] ||
+      try {
+        const displayNameMap = await resolveDisplayNames([
           result.resource.lastUpdatedBy,
-      };
+        ]);
+        result.resource = {
+          ...result.resource,
+          lastUpdatedBy:
+            displayNameMap[result.resource.lastUpdatedBy] ||
+            result.resource.lastUpdatedBy,
+        };
+      } catch (error) {
+        console.error(
+          "Failed to resolve display name for lastUpdatedBy:",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
     }
 
     return NextResponse.json(result, {

--- a/lib/changelog.json
+++ b/lib/changelog.json
@@ -1,6 +1,18 @@
 {
-  "currentVersion": "4.5.1",
+  "currentVersion": "4.5.2",
   "releases": [
+    {
+      "version": "4.5.2",
+      "date": "2026-05-14",
+      "title": "Fix resource card showing Discord ID after update",
+      "type": "patch",
+      "changes": [
+        {
+          "type": "bugfix",
+          "description": "Resource cards now immediately show the user's display name in the 'last updated by' field after an update, instead of briefly flashing the raw Discord ID until the next page refresh."
+        }
+      ]
+    },
     {
       "version": "4.5.1",
       "date": "2026-05-13",


### PR DESCRIPTION
## Summary
Resolves an issue where resource cards would briefly display the raw Discord ID in the "last updated by" field immediately after an update, until the page was refreshed and the display name was fetched.

## Changes
- **`app/api/resources/[id]/route.ts`**: Added display name resolution in the PUT endpoint after a successful resource update
  - Import `resolveDisplayNames` from `lib/users`
  - After updating a resource, resolve the `lastUpdatedBy` Discord ID to its display name before returning the response
  - This ensures the API response includes the human-readable name, allowing the UI to display it immediately without waiting for a page refresh

- **`lib/changelog.json`**: Added v4.5.2 patch release entry documenting the bugfix

## Implementation Details
The fix resolves display names synchronously in the API response using the existing `resolveDisplayNames` utility. This ensures that when the client receives the updated resource object, the `lastUpdatedBy` field already contains the display name instead of the raw Discord ID, eliminating the flash of the ID before the next refresh.

https://claude.ai/code/session_01MMJpAAfV5nZQT2y6iVnV8m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where resource cards briefly displayed a raw identifier in the "last updated by" field instead of immediately showing the user's display name.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sininspira2/ResourceTracker/pull/468)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->