### PR TITLE
Remove dead code

### DIFF
--- a/app/template.tsx
+++ b/app/template.tsx
@@ -1,7 +1,0 @@
-"use client";
-
-import React from "react";
-
-export default function Template({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
-}

--- a/lib/changelog.json
+++ b/lib/changelog.json
@@ -1,6 +1,18 @@
 {
-  "currentVersion": "4.6.0",
+  "currentVersion": "4.6.1",
   "releases": [
+    {
+      "version": "4.6.1",
+      "date": "2026-05-24",
+      "title": "Dead code cleanup",
+      "type": "patch",
+      "changes": [
+        {
+          "type": "improvement",
+          "description": "Removed unused code: deleted the no-op app/template.tsx wrapper and the unused getHierarchyRoles() helper from lib/discord-roles.ts. Demoted several internal-only exports (compareVersions in lib/version.ts and the LEGACY_DIRECTION_*/NEW_DIRECTION_TO_LOCATION_* constants in lib/resource-mapping.ts) to module-private."
+        }
+      ]
+    },
     {
       "version": "4.6.0",
       "date": "2026-05-23",

--- a/lib/discord-roles.ts
+++ b/lib/discord-roles.ts
@@ -136,20 +136,6 @@ export function getHighestRole(userRoles: string[]) {
 }
 
 /**
- * Returns all hierarchy roles the user holds, sorted by `level` descending
- * (highest privilege first). Roles not present in the hierarchy config are omitted.
- *
- * @param userRoles - Array of Discord role IDs from the user's JWT token
- * @returns Filtered and sorted array of `RoleConfig` objects
- */
-export function getHierarchyRoles(userRoles: string[]): Array<RoleConfig> {
-  return userRoles
-    .map((roleId) => getRoleInfo(roleId))
-    .filter((role): role is RoleConfig => role !== undefined)
-    .sort((a, b) => b.level - a.level);
-}
-
-/**
  * Checks whether the user has general resource access (read/view).
  *
  * Returns `false` and logs a warning if no roles in the config have

--- a/lib/resource-mapping.ts
+++ b/lib/resource-mapping.ts
@@ -11,10 +11,10 @@
 export const LEGACY_CATEGORY_BLUEPRINTS = "Blueprints";
 export const NEW_CATEGORY_GEAR_BLUEPRINTS = "Gear Blueprints";
 
-export const LEGACY_DIRECTION_TO_HAGGA = "to_hagga";
-export const LEGACY_DIRECTION_TO_DEEP_DESERT = "to_deep_desert";
-export const NEW_DIRECTION_TO_LOCATION_1 = "transfer_to_location_1";
-export const NEW_DIRECTION_TO_LOCATION_2 = "transfer_to_location_2";
+const LEGACY_DIRECTION_TO_HAGGA = "to_hagga";
+const LEGACY_DIRECTION_TO_DEEP_DESERT = "to_deep_desert";
+const NEW_DIRECTION_TO_LOCATION_1 = "transfer_to_location_1";
+const NEW_DIRECTION_TO_LOCATION_2 = "transfer_to_location_2";
 
 /**
  * Maps the legacy category string "Blueprints" to "Gear Blueprints". Leaves

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -70,7 +70,7 @@ export const getReleasesSince = (lastSeenVersion: string): Release[] => {
  * @param b - Second version string (e.g. `"1.2.0"`)
  * @returns `1` if `a > b`, `-1` if `a < b`, `0` if equal
  */
-export const compareVersions = (a: string, b: string): number => {
+const compareVersions = (a: string, b: string): number => {
   const parseVersion = (version: string) =>
     version.split(".").map((num) => parseInt(num, 10));
 


### PR DESCRIPTION
- Delete app/template.tsx, a no-op pass-through wrapper that was never imported and added an unnecessary render layer.
- Remove getHierarchyRoles() from lib/discord-roles.ts (no callers, no tests).
- Demote internal-only exports to module-private: compareVersions in lib/version.ts and LEGACY_DIRECTION_*/NEW_DIRECTION_TO_LOCATION_* constants in lib/resource-mapping.ts.
- Add changelog entry for 4.6.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 4.6.1 as a maintenance patch focused on improving codebase quality through removal of unused internal exports, elimination of dead code, and refactoring of internal access control utilities to enhance code organization and application maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sininspira2/ResourceTracker/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->